### PR TITLE
Add sliding deque crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+/target
+*~
+*.swp
+*.swo
+
+Cargo.lock
+
+*.data
+*.data.old
+*.strace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,13 @@
+[workspace]
+
+members = [
+  "sliding_deque",
+]
+
+resolver = "2"
+
+[workspace.lints.rust]
+missing_docs = "warn"
+
+[workspace.lints.rustdoc]
+missing_crate_level_docs = "warn"

--- a/sliding_deque/Cargo.toml
+++ b/sliding_deque/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "sliding_deque"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+smallvec = "1"
+
+[lints]
+workspace = true

--- a/sliding_deque/src/lib.rs
+++ b/sliding_deque/src/lib.rs
@@ -1,0 +1,85 @@
+//! The `sliding_deque` crate defines the [`SlidingDeque`] and [`SortedDeque`]
+//! container wrappers.
+//!
+//! The base [`SlidingDeque`] is similar to the standard [`VecDeque`], but
+//! only allows pushing to the back of the queue (consumers can still pull
+//! from both ends), and always keeps the elements ordered in a single
+//! contiguous slice.  Unlike [`VecDeque`], [`SlidingDeque`] is defined as a
+//! wrapper over an arbitrary container type; this crate comes with support
+//! for [`Vec`] for the regular case, and [`SmallVec`] for queues that are
+//! usually small.
+//!
+//! A [`SlidingDeque`] may only be used on (mem)Copy-able items, and tends to
+//! waste more memory than a regular [`VecDeque`], in order to amortise
+//! keeping elements in a contiguous slice.  The constant factors may however
+//! be lower for [`SlidingDeque`] than [`VecDeque`], especially for workloads
+//! that benefit from the ability to access all the elements in a single
+//! ordered slice.
+//!
+//! The [`SortedDeque`] wrapper extends [`SlidingDeque`] to simple use cases
+//! where items are always inserted in sorted order, and *usually* but not
+//! always removed from the ends (e.g., in FIFO order).  It makes the most
+//! sense for small datasets, when storing the sorted collection in, e.g., a
+//! [`SmallVec`], is important.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use sliding_deque::SlidingSmallVec;
+//!
+//! let mut deque : SlidingSmallVec<[u32; 4]> = SlidingSmallVec::new();
+//! deque.push_back(1);
+//! deque.push_back(2);
+//! assert_eq!(deque.pop_front(), Some(1));
+//! assert_eq!(&*deque, &[2]);
+//! ```
+//!
+//! ```rust
+//! use sliding_deque::SortedDeque;
+//!
+//! let mut sorted_deque: SortedDeque<Vec<(u32, Option<()>)>> = Default::default();
+//! // Insertions must be in order! It's a programmer error to insert out-of-order,
+//! // or to insert the same value twice, so the method panics on violations.
+//! sorted_deque.push_back_or_panic((1, Some(())));
+//! sorted_deque.push_back_or_panic((3, Some(())));
+//! sorted_deque.push_back_or_panic((4, Some(())));
+//!
+//! assert_eq!(sorted_deque.find(&1), Some(&(1, Some(()))));
+//! assert_eq!(sorted_deque.find(&2), None);
+//! assert_eq!(sorted_deque.find(&3), Some(&(3, Some(()))));
+//! assert_eq!(sorted_deque.find(&4), Some(&(4, Some(()))));
+//!
+//! sorted_deque.remove(&3);
+//! assert_eq!(sorted_deque.find(&3), None);
+//!
+//! assert_eq!(sorted_deque.pop_first(), Some((1, Some(()))));
+//! assert_eq!(sorted_deque.find(&1), None);
+//!
+//! assert_eq!(sorted_deque.first(), Some(&(4, Some(()))));
+//! assert_eq!(sorted_deque.last(), Some(&(4, Some(()))));
+//! ```
+//!
+//! [`VecDeque`]: std::collections::VecDeque
+//! [`SmallVec`]: smallvec::SmallVec
+
+mod sliding_deque;
+mod sorted_deque;
+
+pub use sliding_deque::SlidingDeque;
+pub use sliding_deque::SlidingSmallVec;
+pub use sliding_deque::SlidingVec;
+
+pub use sorted_deque::SortedDeque;
+
+pub mod traits {
+    //! The `traits` module contains optional traits to extend the default
+    //! functionality in the `sliding_deque` crate.
+    //!
+    //! Basic usage should not need to implement these traits, but they are
+    //! useful (the `SortedDeque` traits in particular) for complex use cases.
+
+    pub use crate::sliding_deque::PushTruncateContainer;
+    pub use crate::sorted_deque::SortedDequeComparator;
+    pub use crate::sorted_deque::SortedDequeItem;
+    pub use crate::sorted_deque::SortedDequeMarker;
+}

--- a/sliding_deque/src/sliding_deque.rs
+++ b/sliding_deque/src/sliding_deque.rs
@@ -1,0 +1,499 @@
+//! The `sliding_deque` module defines the [`SlidingDeque`] container
+//! wrapper.  It's similar to the standard
+//! [`std::collections::VecDeque`], but accepts multiple underlying
+//! container types ([`Vec`] for the regular case, and [`SmallVec`]
+//! for queues that are usually small), and maintains the elements in
+//! order, in a single contiguous slice.
+use smallvec::SmallVec;
+
+/// In order to implement a sliding deque, we need an underlying
+/// container that can push/pop from the end, truncate to a prefix
+/// of the elements, and expose its contents as a contiguous slice.
+pub trait PushTruncateContainer {
+    /// The type of each value in the container.
+    type Item;
+
+    /// Pushes `value` to the end of the container.
+    fn push(&mut self, value: Self::Item);
+    /// Pops the last value in the container
+    fn pop(&mut self) -> Option<Self::Item>;
+    /// Shrinks the container to the first `len` elements
+    fn truncate(&mut self, len: usize);
+
+    /// Returns a single contiguous slice for the container's
+    /// elements, in order.
+    fn slice(&self) -> &[Self::Item];
+
+    /// Returns a single contiguous mutable slice for the container's
+    /// elements, in order.
+    fn slice_mut(&mut self) -> &mut [Self::Item];
+}
+
+/// A [`SlidingDeque`] wraps a vector-like container with amortised
+/// constant-time push to the end, and augments it with an amortised
+/// constant-time consumption from the front.
+///
+/// Pushing forwards to the underlying container's `push` method.
+///
+/// Consuming from the front increments a read pointer and periodically
+/// shifts the container's contents forward, over consumed elements,
+/// also in amortised constant time.
+///
+/// The [`SlidingDeque`] internally wastes up to half the space on
+/// consumed but yet unshifted elements; a typical growable container
+/// will waste up to half of its own space on buffer space for `push`.
+/// In total, we can expect up to 4x space overhead for a [`SlidingDeque`]
+/// (i.e., the maximum heap footprint will be up to 4x the maximum
+/// number of logically live items in the container).
+#[derive(Clone, Debug, Default)]
+pub struct SlidingDeque<Container>
+where
+    Container: PushTruncateContainer + Clone + Default,
+    <Container as PushTruncateContainer>::Item: Copy,
+{
+    consumed_prefix: usize,
+    container: Container,
+}
+
+/// A [`SlidingVec`] where the backing storage is a [`Vec<T>`]
+pub type SlidingVec<T> = SlidingDeque<Vec<T>>;
+
+/// A [`SlidingVec`] where the backing storage is a [`SmallVec<Array>`],
+/// e.g., `SlidingSmallVec<[u32; 8]>`.
+#[allow(dead_code)]
+pub type SlidingSmallVec<Array> = SlidingDeque<SmallVec<Array>>;
+
+impl<Container: PushTruncateContainer + Clone + Default> SlidingDeque<Container>
+where
+    <Container as PushTruncateContainer>::Item: Copy,
+{
+    /// Creates a new empty [`SlidingDeque`]
+    #[must_use]
+    #[inline(always)]
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Pushes `item` to the back of the [`SlidingDeque`]
+    #[inline(always)]
+    pub fn push_back(&mut self, item: Container::Item) {
+        self.container.push(item)
+    }
+
+    /// Returns a reference to the first element in the [`SlidingDeque`],
+    /// if any.
+    #[must_use]
+    #[inline(always)]
+    pub fn front(&self) -> Option<&Container::Item> {
+        self.first()
+    }
+
+    /// Returns a mutable reference to the first element in the
+    /// [`SlidingDeque`], if any.
+    #[must_use]
+    #[inline(always)]
+    pub fn front_mut(&mut self) -> Option<&mut Container::Item> {
+        self.first_mut()
+    }
+
+    /// Consumes and returns the first element in the
+    /// [`SlidingDeque`], if any.
+    pub fn pop_front(&mut self) -> Option<Container::Item> {
+        let ret = *self.front()?;
+        self.consumed_prefix += 1;
+        self.maybe_slide();
+        Some(ret)
+    }
+
+    /// Returns a reference to the last element in the [`SlidingDeque`],
+    /// if any.
+    #[must_use]
+    #[inline(always)]
+    pub fn back(&self) -> Option<&Container::Item> {
+        self.last()
+    }
+
+    /// Returns a mutable reference to the last element in the
+    /// [`SlidingDeque`], if any.
+    #[must_use]
+    #[inline(always)]
+    pub fn back_mut(&mut self) -> Option<&mut Container::Item> {
+        self.last_mut()
+    }
+
+    /// Consumes and returns the last element in the [`SlidingDeque`],
+    /// if any.
+    pub fn pop_back(&mut self) -> Option<Container::Item> {
+        // This checks that we haven't consumed all the elements.
+        let ret = *self.back()?;
+
+        self.container.pop().expect("must be non-empty");
+
+        // We did some work if we get here; check if we reached
+        // an empty state.
+        if self.is_empty() {
+            self.clear();
+        }
+
+        Some(ret)
+    }
+
+    /// Consumes the first `count` elements in the [`SlidingDeque`].
+    ///
+    /// Returns the actual number of elements consumed, which may
+    /// be less than `count` if we ran out of values.
+    #[must_use]
+    pub fn advance(&mut self, count: usize) -> usize {
+        let to_consume = self
+            .container
+            .slice()
+            .len()
+            .saturating_sub(self.consumed_prefix)
+            .min(count);
+
+        self.consumed_prefix += to_consume;
+        self.maybe_slide();
+
+        to_consume
+    }
+
+    /// Removes all elements from this [`SlidingDeque`], and restores
+    /// the internal state to the optimal empty state.
+    #[inline(always)]
+    pub fn clear(&mut self) {
+        self.container.truncate(0);
+        self.consumed_prefix = 0;
+    }
+
+    #[inline(always)]
+    fn maybe_slide(&mut self) {
+        // Either there's enough slots pending cleanup to justify the slide, or
+        // the cleanup will be constant-time.
+        if (self.consumed_prefix > self.container.slice().len() / 2) | self.is_empty() {
+            self.slide();
+        }
+    }
+
+    /// Removes any previously consumed value from the container.
+    ///
+    /// This does not change the logical contents of the deque, and is
+    /// merely a space optimisation (at the expense of time).
+    #[inline(never)]
+    pub fn slide(&mut self) {
+        #[cfg(not(test))]
+        if self.consumed_prefix == 0 {
+            return;
+        }
+
+        self.container
+            .slice_mut()
+            .copy_within(self.consumed_prefix.., 0);
+        self.container.truncate(
+            self.container
+                .slice()
+                .len()
+                .saturating_sub(self.consumed_prefix),
+        );
+        self.consumed_prefix = 0;
+    }
+}
+
+impl<Container> std::ops::Deref for SlidingDeque<Container>
+where
+    Container: PushTruncateContainer + Clone + Default,
+    <Container as PushTruncateContainer>::Item: Copy,
+{
+    type Target = [<Container as PushTruncateContainer>::Item];
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        &self.container.slice()[self.consumed_prefix..]
+    }
+}
+
+impl<Container> std::ops::DerefMut for SlidingDeque<Container>
+where
+    Container: PushTruncateContainer + Clone + Default,
+    <Container as PushTruncateContainer>::Item: Copy,
+{
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.container.slice_mut()[self.consumed_prefix..]
+    }
+}
+
+impl<Container> From<Container> for SlidingDeque<Container>
+where
+    Container: PushTruncateContainer + Clone + Default,
+    <Container as PushTruncateContainer>::Item: Copy,
+{
+    #[inline(always)]
+    fn from(container: Container) -> SlidingDeque<Container> {
+        SlidingDeque {
+            consumed_prefix: 0,
+            container,
+        }
+    }
+}
+
+impl<T: Copy> PushTruncateContainer for Vec<T> {
+    type Item = T;
+
+    #[inline(always)]
+    fn push(&mut self, value: T) {
+        self.push(value)
+    }
+
+    #[inline(always)]
+    fn pop(&mut self) -> Option<Self::Item> {
+        self.pop()
+    }
+
+    #[inline(always)]
+    fn truncate(&mut self, len: usize) {
+        self.truncate(len)
+    }
+
+    #[inline(always)]
+    fn slice(&self) -> &[T] {
+        self
+    }
+
+    #[inline(always)]
+    fn slice_mut(&mut self) -> &mut [T] {
+        self
+    }
+}
+
+impl<A> PushTruncateContainer for SmallVec<A>
+where
+    A: smallvec::Array,
+    <A as smallvec::Array>::Item: Copy,
+{
+    type Item = <A as smallvec::Array>::Item;
+
+    #[inline(always)]
+    fn push(&mut self, value: Self::Item) {
+        self.push(value)
+    }
+
+    #[inline(always)]
+    fn pop(&mut self) -> Option<Self::Item> {
+        self.pop()
+    }
+
+    #[inline(always)]
+    fn truncate(&mut self, len: usize) {
+        self.truncate(len)
+    }
+
+    #[inline(always)]
+    fn slice(&self) -> &[Self::Item] {
+        self
+    }
+
+    #[inline(always)]
+    fn slice_mut(&mut self) -> &mut [Self::Item] {
+        self
+    }
+}
+
+#[test]
+fn test_new_miri() {
+    let deque: SlidingVec<i32> = SlidingDeque::new();
+    assert!(deque.is_empty());
+}
+
+#[test]
+fn test_push_back_miri() {
+    let mut deque: SlidingSmallVec<[i32; 4]> = SlidingDeque::new();
+    deque.push_back(1);
+    deque.push_back(2);
+    assert_eq!(deque.front(), Some(&1));
+    assert_eq!(deque.back(), Some(&2));
+}
+
+#[test]
+fn test_pop_front_miri() {
+    let mut deque: SlidingVec<i32> = SlidingDeque::new();
+    deque.push_back(1);
+    deque.push_back(2);
+    assert_eq!(deque.pop_front(), Some(1));
+    assert_eq!(deque.pop_front(), Some(2));
+    assert_eq!(deque.pop_front(), None);
+}
+
+#[test]
+fn test_pop_back_miri() {
+    let mut deque: SlidingVec<i32> = SlidingDeque::new();
+    deque.push_back(1);
+    deque.push_back(2);
+    assert_eq!(deque.pop_back(), Some(2));
+    assert_eq!(deque.pop_back(), Some(1));
+    assert_eq!(deque.pop_back(), None);
+}
+
+#[test]
+fn test_len_miri() {
+    let mut deque: SlidingSmallVec<[i32; 2]> = SlidingDeque::new();
+    assert_eq!(deque.len(), 0);
+    deque.push_back(1);
+    assert_eq!(deque.len(), 1);
+    deque.push_back(2);
+    assert_eq!(deque.len(), 2);
+    deque.pop_front();
+    assert_eq!(deque.len(), 1);
+}
+
+#[test]
+fn test_is_empty_miri() {
+    let mut deque: SlidingVec<i32> = SlidingDeque::new();
+    assert!(deque.is_empty());
+    deque.push_back(1);
+    assert!(!deque.is_empty());
+    deque.pop_back();
+    assert!(deque.is_empty());
+}
+
+#[test]
+fn test_vec_miri() {
+    let mut deque = SlidingDeque::<Vec<u32>>::new();
+
+    // Initially empty
+    assert_eq!(&*deque, &[]);
+    assert_eq!(deque.len(), 0);
+    assert!(deque.is_empty());
+    assert_eq!(deque.front(), None);
+    assert_eq!(deque.pop_front(), None);
+    assert_eq!(deque.back(), None);
+    assert_eq!(deque.pop_back(), None);
+
+    // sliding does nothing
+    deque.slide();
+
+    assert_eq!(deque.advance(10), 0);
+
+    deque.push_back(1);
+    assert_eq!(&*deque, &[1]);
+    assert_eq!(deque.len(), 1);
+    assert!(!deque.is_empty());
+    assert_eq!(deque.front().copied(), Some(1));
+
+    // We can overwrite the slice.
+    deque[0] = 42;
+    assert_eq!(&*deque, &[42]);
+    assert_eq!(&*deque, &[42]);
+    assert_eq!(deque.len(), 1);
+    assert!(!deque.is_empty());
+
+    // we can peek at the front.
+    assert_eq!(deque.front().copied(), Some(42));
+
+    // And pop the back
+    assert_eq!(deque.pop_back(), Some(42));
+
+    deque.slide();
+}
+
+#[test]
+fn test_vec_pop_back_miri() {
+    let mut deque = SlidingDeque::<Vec<u32>>::new();
+
+    deque.push_back(0);
+    deque.push_back(1);
+
+    assert_eq!(deque.pop_back(), Some(1));
+    assert_eq!(deque.pop_back(), Some(0));
+    assert_eq!(deque.pop_back(), None);
+}
+
+#[test]
+fn test_vec_pop_advance_miri() {
+    let mut deque = SlidingDeque::<Vec<u32>>::new();
+
+    deque.push_back(0);
+    deque.push_back(1);
+
+    assert_eq!(deque.pop_back(), Some(1));
+    assert_eq!(deque.advance(2), 1);
+    assert_eq!(deque.pop_back(), None);
+}
+
+#[test]
+fn test_vec_advance_miri() {
+    let mut deque = SlidingDeque::<Vec<u32>>::new();
+
+    deque.push_back(0);
+    deque.push_back(1);
+
+    let _ = deque.advance(1);
+    assert_eq!(deque.pop_back(), Some(1));
+    assert_eq!(deque.pop_back(), None);
+}
+
+#[test]
+fn test_vec_advance2_miri() {
+    let mut deque = SlidingDeque::<Vec<u32>>::new();
+
+    deque.push_back(0);
+    deque.push_back(1);
+
+    let _ = deque.advance(2);
+    assert_eq!(deque.pop_back(), None);
+}
+
+#[test]
+fn test_smallvec_miri() {
+    let mut deque = SlidingDeque::<SmallVec<[u8; 8]>>::new();
+
+    // Initially empty
+    assert_eq!(&*deque, &[]);
+    assert_eq!(deque.len(), 0);
+    assert!(deque.is_empty());
+    assert_eq!(deque.front(), None);
+    assert_eq!(deque.pop_front(), None);
+
+    assert_eq!(deque.advance(10), 0);
+
+    deque.push_back(1);
+    assert_eq!(&*deque, &[1]);
+    assert_eq!(deque.len(), 1);
+    assert!(!deque.is_empty());
+    assert_eq!(deque.front().copied(), Some(1));
+
+    // We can overwrite the slice.
+    *deque.front_mut().unwrap() = 42;
+    assert_eq!(&*deque, &[42]);
+    assert_eq!(&*deque, &[42]);
+    assert_eq!(deque.len(), 1);
+    assert!(!deque.is_empty());
+
+    deque.push_back(2);
+    deque.push_back(3);
+    deque.push_back(4);
+
+    assert_eq!(&*deque, &[42, 2, 3, 4]);
+
+    // we can peek at the front.
+    assert_eq!(deque.front().copied(), Some(42));
+    assert_eq!(deque.pop_front(), Some(42));
+    assert_eq!(&*deque, &[2, 3, 4]);
+
+    // Sliding forward doesn't change the contents.
+    deque.slide();
+    assert_eq!(&*deque, &[2, 3, 4]);
+
+    assert_eq!(deque.pop_back(), Some(4));
+    assert_eq!(&*deque, &[2, 3]);
+
+    *deque.back_mut().unwrap() = 10;
+    assert_eq!(&*deque, &[2, 10]);
+}
+
+#[test]
+fn test_from_vec_miri() {
+    let mut deque: SlidingDeque<Vec<u8>> = vec![0u8].into();
+
+    assert_eq!(deque.pop_front(), Some(0u8));
+    assert!(deque.is_empty());
+}

--- a/sliding_deque/src/sorted_deque.rs
+++ b/sliding_deque/src/sorted_deque.rs
@@ -1,0 +1,678 @@
+//! The `sorted_deque` module exposes the [`SortedDeque`]
+//! container, as well as associated traits.
+//!
+//! A [`SortedDeque`] wraps a [`SlidingDeque`] to implement a special
+//! case of sorted containers:
+//!
+//! - values may only be inserted at the end (i.e., in strictly ascending order)
+//! - values may be searched (with binary search)
+//! - values may be marked as logically deleted, but are only physically deleted
+//!   when they're the first or last value in FIFO (sorted) order.
+//!
+//! Insertion amortises to constant time, lookups are logarithmic time (although
+//! we must take into account items that are logically but not yet physically
+//! deleted), and deletion takes as much time as a lookup plus some amortised
+//! constant-time overhead.
+use std::cmp::Ordering;
+
+use crate::sliding_deque::PushTruncateContainer;
+use crate::SlidingDeque;
+
+/// In the general case, a [`SortedDeque`] accepts an object that
+/// implements the methods we need on an arbitrary type.
+///
+/// There is a blanket definition for `(Key, Option<Value>)` pairs where
+/// the pair is [`Copy`]able, and the `Key` implements [`Ord`].
+///
+/// There is also a default definition for types that implement
+/// [`SortedDequeItem`].
+pub trait SortedDequeComparator<T> {
+    /// Items have a key for comparisons.  The simple case is
+    /// that the whole `T` is the comparison key, but it makes
+    /// sense to have a subset of the item as a key, e.g., for
+    /// key-value pairs.
+    ///
+    /// Lookup operations work in terms of `Key`, not `T`.
+    type Key;
+
+    /// We can extract a comparison key from an item.
+    ///
+    /// The key is returned by value to allow complex extraction
+    /// logic, and because `T` must be copyable to fit in a
+    /// [`SlidingDeque`]
+    fn extract_key(&self, item: &T) -> Self::Key;
+
+    /// And we can compare keys.
+    fn cmp(&self, x: &Self::Key, y: &Self::Key) -> std::cmp::Ordering;
+
+    /// Check whether an item is erased.
+    ///
+    /// Defaults to always false; should be overridden when
+    /// `SortedDequeMarker` is implemented.
+    #[inline(always)]
+    fn is_erased(&self, item: &T) -> bool {
+        let _ = item;
+        false
+    }
+}
+
+/// A [`SortedDequeMarker`] is a [`SortedDequeComparator`] that can also
+/// mark items as deleted.
+///
+/// There is a blanket definition for `(Key, Option<Value>)` pairs where
+/// the pair is [`Copy`]able, and the `Key` implements [`Ord`]: a `None`
+/// value represents a logically deleted item.
+///
+/// There is also a default definition for types that implement
+/// [`SortedDequeItem`].
+pub trait SortedDequeMarker<T>: SortedDequeComparator<T> {
+    /// We can mark an item as erased.
+    ///
+    /// Implementors of this trait must also implement
+    /// [`SortedDequeComparator::is_erased`].
+    fn mark_erased(&self, item: &mut T);
+}
+
+/// In the simple case [`SortedDeque`] supports any type that
+/// implements [`Ord`] and the new `mark_erased` / `is_erased`
+/// operations: we'll just compare the whole object.
+pub trait SortedDequeItem: Ord {
+    /// Marks the item as erased.
+    fn mark_erased(&mut self);
+
+    /// Determines wheter the item was erased.
+    fn is_erased(&self) -> bool;
+}
+
+/// And from `SortedDequeItem`, we can implement a stateless
+/// `SortedDequeMarker`.
+impl<T: SortedDequeItem + Copy> SortedDequeComparator<T> for () {
+    type Key = T;
+
+    #[inline(always)]
+    fn extract_key(&self, item: &T) -> T {
+        *item
+    }
+
+    #[inline(always)]
+    fn cmp(&self, x: &T, y: &T) -> Ordering {
+        x.cmp(y)
+    }
+
+    #[inline(always)]
+    fn is_erased(&self, item: &T) -> bool {
+        item.is_erased()
+    }
+}
+
+impl<T: SortedDequeItem + Copy> SortedDequeMarker<T> for () {
+    #[inline(always)]
+    fn mark_erased(&self, item: &mut T) {
+        item.mark_erased();
+        assert!(item.is_erased());
+    }
+}
+
+/// We also have an easy implementation for pairs of key and optional value.
+impl<Key: Copy + Ord, Value: Copy> SortedDequeComparator<(Key, Option<Value>)> for () {
+    type Key = Key;
+
+    #[inline(always)]
+    fn extract_key(&self, item: &(Key, Option<Value>)) -> Key {
+        item.0
+    }
+
+    #[inline(always)]
+    fn cmp(&self, x: &Key, y: &Key) -> Ordering {
+        x.cmp(y)
+    }
+
+    #[inline(always)]
+    fn is_erased(&self, item: &(Key, Option<Value>)) -> bool {
+        item.1.is_none()
+    }
+}
+
+impl<Key: Copy + Ord, Value: Copy> SortedDequeMarker<(Key, Option<Value>)> for () {
+    #[inline(always)]
+    fn mark_erased(&self, item: &mut (Key, Option<Value>)) {
+        item.1 = None;
+    }
+}
+
+/// A [`SortedDeque`] is a contiguous container wrapped in a restricted
+/// sorted container.
+///
+/// Items may be:
+///
+/// - inserted in strictly increasing order at the end in amortised constant time
+/// - popped from either end in amortised constant time
+/// - searched for in logarithmic time (as a function of *physically* live items)
+/// - removed in amortised logarithmic time (modulo some additional slowdown
+///   in the search until the items are removed physically)
+///
+/// We could also periodically compact away items that were deleted logically
+/// but not yet physically, at an amortised constant-time cost.  That is not
+/// currently implemented because we expect most deletions to happen in FIFO
+/// order, in which case amortised sweeping is a useless complication.
+#[derive(Clone, Debug)]
+pub struct SortedDeque<Container, Marker = ()>
+where
+    Container: PushTruncateContainer + Clone + Default,
+    <Container as PushTruncateContainer>::Item: Copy,
+    Marker: SortedDequeComparator<<Container as PushTruncateContainer>::Item> + Clone,
+{
+    /// Values in the `items` deque may be logically erased, except for the
+    /// first/last: we always clean up from both ends.
+    items: SlidingDeque<Container>,
+    marker: Marker,
+}
+
+impl<Container, Marker> Default for SortedDeque<Container, Marker>
+where
+    Container: PushTruncateContainer + Clone + Default,
+    Container::Item: Copy,
+    Marker: SortedDequeComparator<Container::Item> + Clone + Default,
+{
+    #[inline(always)]
+    fn default() -> Self {
+        Self::new(Default::default(), Default::default())
+    }
+}
+
+impl<Container, Marker> SortedDeque<Container, Marker>
+where
+    Container: PushTruncateContainer + Clone + Default,
+    Container::Item: Copy,
+    Marker: SortedDequeComparator<Container::Item> + Clone,
+{
+    /// Creates a fresh `SortedDeque` from the given `items` and `marker`.
+    #[must_use]
+    #[inline(always)]
+    pub fn new(items: Container, marker: Marker) -> Self {
+        Self {
+            items: items.into(),
+            marker,
+        }
+    }
+
+    /// Pushes `item` to the end of the [`SortedDeque`].
+    ///
+    /// Panics if the `item` isn't strictly greater than the
+    /// last element, if any.
+    ///
+    /// No-ops if `item` is already erased.
+    pub fn push_back_or_panic(&mut self, item: Container::Item) {
+        if self.marker.is_erased(&item) {
+            return;
+        }
+
+        if let Some(back) = self.items.back() {
+            assert_eq!(
+                self.marker.cmp(
+                    &self.marker.extract_key(back),
+                    &self.marker.extract_key(&item)
+                ),
+                Ordering::Less
+            );
+        }
+
+        self.items.push_back(item);
+    }
+
+    /// Removes all items from `self`.
+    #[inline(always)]
+    pub fn clear(&mut self) {
+        self.items.clear()
+    }
+
+    /// Determines whether we have no item in the container.
+    #[must_use]
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    /// Returns an iterator for the (non-erased) items in the [`SortedDeque`],
+    /// in FIFO (and thus sorted) order.
+    #[inline(always)]
+    pub fn iter(&self) -> impl Iterator<Item = &Container::Item> {
+        self.items
+            .iter()
+            .filter(|item| !self.marker.is_erased(item))
+    }
+
+    /// Returns the first (least-valued) item, if we have one.
+    #[must_use]
+    #[inline(always)]
+    pub fn first(&self) -> Option<&Container::Item> {
+        self.items.front()
+    }
+
+    /// Consumes and returns the first item.
+    #[inline(never)]
+    pub fn pop_first(&mut self) -> Option<Container::Item> {
+        let ret = self.items.pop_front()?;
+        self.cleanup_front();
+        Some(ret)
+    }
+
+    /// Returns the last (highest valued) item, if we have one
+    #[must_use]
+    #[inline(always)]
+    pub fn last(&self) -> Option<&Container::Item> {
+        self.items.back()
+    }
+
+    /// Consumes and returns the last item.
+    #[inline(never)]
+    pub fn pop_last(&mut self) -> Option<Container::Item> {
+        let ret = self.items.pop_back()?;
+        self.cleanup_back();
+        Some(ret)
+    }
+
+    /// Looks for the item that matches `key`.
+    #[must_use]
+    pub fn find(&self, key: &Marker::Key) -> Option<&Container::Item> {
+        let idx = self.find_index(key)?;
+
+        let item = &self.items[idx];
+        if self.marker.is_erased(item) {
+            None
+        } else {
+            Some(item)
+        }
+    }
+
+    /// Find the index of the item that corresponds to `key`, if any.
+    #[must_use]
+    #[inline(always)]
+    fn find_index(&self, key: &Marker::Key) -> Option<usize> {
+        let comparator = |item| self.marker.cmp(&self.marker.extract_key(item), key);
+        self.items.binary_search_by(comparator).ok()
+    }
+
+    /// Removes any newly exposed erased item at the back of the underlying deque.
+    #[inline(always)]
+    fn cleanup_back(&mut self) {
+        while let Some(back) = self.items.back() {
+            if !self.marker.is_erased(back) {
+                break;
+            }
+
+            self.items.pop_back();
+        }
+    }
+
+    /// Removes any newly exposed erased item at the front of the underlying deque.
+    #[inline(always)]
+    fn cleanup_front(&mut self) {
+        let mut to_drop = usize::MAX;
+        // Find the index of the first non-deleted item
+        for (idx, item) in self.items.iter().enumerate() {
+            if !self.marker.is_erased(item) {
+                to_drop = idx;
+                break;
+            }
+        }
+
+        let _ = self.items.advance(to_drop);
+    }
+}
+
+impl<Container, Marker> SortedDeque<Container, Marker>
+where
+    Container: PushTruncateContainer + Clone + Default,
+    Container::Item: Copy,
+    Marker: SortedDequeMarker<Container::Item> + Clone,
+{
+    /// Looks for the item that matches `key`, and removes it
+    /// if it is found.
+    ///
+    /// Once removed, an item will not be found again.
+    #[inline(never)]
+    pub fn remove(&mut self, key: &Marker::Key) -> Option<Container::Item> {
+        let len = self.items.len();
+        let idx = self.find_index(key)?;
+
+        let item = &mut self.items[idx];
+        if self.marker.is_erased(item) {
+            return None;
+        }
+
+        if idx == 0 {
+            // The `pop_first` method is better for large batches;
+            // prefer to call that if we removed the last item.
+            self.pop_first()
+        } else if idx == len - 1 {
+            self.pop_last()
+        } else {
+            // Deletion from the middle, can only erase logically.
+            let ret = *item;
+
+            self.marker.mark_erased(item);
+            assert!(self.marker.is_erased(item));
+            Some(ret)
+        }
+    }
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq)]
+struct TestItem {
+    key: u32,
+    value: Option<std::num::NonZeroU32>,
+}
+
+#[cfg(test)]
+impl SortedDequeItem for TestItem {
+    fn mark_erased(&mut self) {
+        self.value = None
+    }
+
+    fn is_erased(&self) -> bool {
+        self.value.is_none()
+    }
+}
+
+#[test]
+fn test_happy_path_miri() {
+    let mut deque: SortedDeque<Vec<TestItem>> = Default::default();
+
+    assert!(deque.is_empty());
+    assert_eq!(deque.first(), None);
+    assert_eq!(deque.pop_first(), None);
+    assert_eq!(deque.last(), None);
+    assert_eq!(deque.pop_last(), None);
+
+    let item = TestItem {
+        key: 0,
+        value: Some(1.try_into().unwrap()),
+    };
+    assert_eq!(deque.find(&item), None);
+    assert_eq!(deque.iter().copied().collect::<Vec<_>>(), []);
+
+    deque.push_back_or_panic(item);
+    assert!(!deque.is_empty());
+    assert_eq!(deque.iter().copied().collect::<Vec<_>>(), [item]);
+
+    assert_eq!(deque.first(), Some(&item));
+    assert_eq!(deque.last(), Some(&item));
+
+    assert_eq!(deque.find(&item), Some(&item));
+    // No false match.
+    assert_eq!(
+        deque.find(&TestItem {
+            key: 1,
+            value: Some(1.try_into().unwrap())
+        }),
+        None
+    );
+    assert_eq!(
+        deque.find(&TestItem {
+            key: 0,
+            value: None
+        }),
+        None
+    );
+
+    assert_eq!(deque.remove(&item), Some(item));
+
+    assert!(deque.is_empty());
+}
+
+#[test]
+fn test_remove_middle_miri() {
+    let mut deque: SortedDeque<Vec<TestItem>> = Default::default();
+
+    let items = [
+        TestItem {
+            key: 0,
+            value: Some(1.try_into().unwrap()),
+        },
+        TestItem {
+            key: 1,
+            value: Some(1.try_into().unwrap()),
+        },
+        TestItem {
+            key: 2,
+            value: Some(1.try_into().unwrap()),
+        },
+        // This one is already deleted, should no-op.
+        TestItem {
+            key: 0,
+            value: None,
+        },
+    ];
+    assert_eq!(deque.find(&items[0]), None);
+
+    deque.push_back_or_panic(items[0]);
+    deque.push_back_or_panic(items[1]);
+    deque.push_back_or_panic(items[2]);
+    deque.push_back_or_panic(items[3]);
+
+    assert!(!deque.is_empty());
+
+    assert_eq!(deque.first(), Some(&items[0]));
+    assert_eq!(deque.last(), Some(&items[2]));
+
+    assert_eq!(deque.find(&items[0]), Some(&items[0]));
+    assert_eq!(deque.find(&items[1]), Some(&items[1]));
+    assert_eq!(deque.find(&items[2]), Some(&items[2]));
+    assert_eq!(deque.find(&items[3]), None);
+
+    assert_eq!(deque.remove(&items[1]), Some(items[1]));
+
+    assert_eq!(deque.find(&items[0]), Some(&items[0]));
+    assert_eq!(deque.find(&items[1]), None);
+    assert_eq!(deque.find(&items[2]), Some(&items[2]));
+
+    assert_eq!(deque.remove(&items[0]), Some(items[0]));
+
+    assert_eq!(deque.first(), Some(&items[2]));
+    assert_eq!(deque.last(), Some(&items[2]));
+
+    assert_eq!(deque.remove(&items[2]), Some(items[2]));
+
+    assert!(deque.is_empty());
+}
+
+#[test]
+fn test_remove_middle_then_pop_miri() {
+    let mut deque: SortedDeque<Vec<TestItem>> = Default::default();
+
+    let items = [
+        TestItem {
+            key: 0,
+            value: Some(1.try_into().unwrap()),
+        },
+        TestItem {
+            key: 1,
+            value: Some(1.try_into().unwrap()),
+        },
+        TestItem {
+            key: 2,
+            value: Some(1.try_into().unwrap()),
+        },
+    ];
+    assert_eq!(deque.find(&items[0]), None);
+
+    deque.push_back_or_panic(items[0]);
+    deque.push_back_or_panic(items[1]);
+    deque.push_back_or_panic(items[2]);
+
+    assert!(!deque.is_empty());
+
+    assert_eq!(deque.first(), Some(&items[0]));
+    assert_eq!(deque.last(), Some(&items[2]));
+
+    assert_eq!(deque.find(&items[0]), Some(&items[0]));
+    assert_eq!(deque.find(&items[1]), Some(&items[1]));
+    assert_eq!(deque.find(&items[2]), Some(&items[2]));
+
+    assert_eq!(deque.remove(&items[1]), Some(items[1]));
+
+    assert_eq!(deque.find(&items[0]), Some(&items[0]));
+    assert_eq!(deque.find(&items[1]), None);
+    assert_eq!(deque.find(&items[2]), Some(&items[2]));
+
+    assert_eq!(deque.pop_last(), Some(items[2]));
+
+    assert_eq!(deque.find(&items[0]), Some(&items[0]));
+    assert_eq!(deque.find(&items[1]), None);
+    assert_eq!(deque.find(&items[2]), None);
+    assert_eq!(deque.pop_first(), Some(items[0]));
+
+    assert!(deque.is_empty());
+}
+
+#[test]
+fn test_key_val_miri() {
+    type Entry = (u32, Option<()>);
+    let mut deque: SortedDeque<smallvec::SmallVec<[Entry; 4]>> = Default::default();
+
+    deque.push_back_or_panic((1, Some(())));
+    deque.push_back_or_panic((2, Some(())));
+    deque.push_back_or_panic((1, None));
+    deque.push_back_or_panic((3, Some(())));
+
+    assert_eq!(deque.find(&0), None);
+    assert_eq!(deque.remove(&0), None);
+
+    assert_eq!(deque.find(&1), Some(&(1, Some(()))));
+    assert_eq!(deque.find(&2), Some(&(2, Some(()))));
+    assert_eq!(deque.find(&3), Some(&(3, Some(()))));
+    assert_eq!(deque.find(&4), None);
+
+    assert_eq!(deque.remove(&2), Some((2, Some(()))));
+    assert_eq!(deque.remove(&2), None);
+
+    assert_eq!(deque.find(&1), Some(&(1, Some(()))));
+    assert_eq!(deque.find(&2), None);
+    assert_eq!(deque.find(&3), Some(&(3, Some(()))));
+
+    assert_eq!(deque.remove(&3), Some((3, Some(()))));
+    assert_eq!(deque.find(&3), None);
+
+    assert_eq!(deque.remove(&1), Some((1, Some(()))));
+
+    assert!(deque.is_empty());
+}
+
+#[test]
+#[should_panic(expected = "left: Greater")]
+fn test_push_back_or_panic_miri() {
+    let mut deque: SortedDeque<Vec<TestItem>> = Default::default();
+
+    let item1 = TestItem {
+        key: 1,
+        value: Some(1.try_into().unwrap()),
+    };
+    let item2 = TestItem {
+        key: 2,
+        value: Some(2.try_into().unwrap()),
+    };
+    let item3 = TestItem {
+        key: 1,
+        value: Some(3.try_into().unwrap()),
+    }; // Not strictly greater
+
+    deque.push_back_or_panic(item1);
+    deque.push_back_or_panic(item2);
+
+    // This should panic
+    deque.push_back_or_panic(item3);
+}
+
+#[test]
+fn test_pop_first_and_last_miri() {
+    let mut deque: SortedDeque<Vec<TestItem>> = Default::default();
+
+    let item1 = TestItem {
+        key: 1,
+        value: Some(1.try_into().unwrap()),
+    };
+    let item2 = TestItem {
+        key: 2,
+        value: Some(2.try_into().unwrap()),
+    };
+
+    deque.push_back_or_panic(item1);
+    deque.push_back_or_panic(item2);
+
+    assert_eq!(deque.pop_first(), Some(item1));
+    assert_eq!(deque.pop_last(), Some(item2));
+    assert!(deque.is_empty());
+}
+
+#[test]
+fn test_erasure_logic_miri() {
+    let mut deque: SortedDeque<Vec<TestItem>> = Default::default();
+
+    let item1 = TestItem {
+        key: 1,
+        value: Some(1.try_into().unwrap()),
+    };
+    let item2 = TestItem {
+        key: 2,
+        value: Some(2.try_into().unwrap()),
+    };
+
+    deque.push_back_or_panic(item1);
+    deque.push_back_or_panic(item2);
+
+    deque.remove(&item2);
+
+    assert_eq!(deque.find(&item2), None);
+}
+
+#[test]
+fn test_find_miri() {
+    let mut deque: SortedDeque<Vec<TestItem>> = Default::default();
+
+    let item1 = TestItem {
+        key: 1,
+        value: Some(1.try_into().unwrap()),
+    };
+    let item2 = TestItem {
+        key: 2,
+        value: Some(2.try_into().unwrap()),
+    };
+
+    deque.push_back_or_panic(item1);
+    deque.push_back_or_panic(item2);
+
+    assert_eq!(deque.find(&item1), Some(&item1));
+    assert_eq!(deque.find(&item2), Some(&item2));
+    assert_eq!(
+        deque.find(&TestItem {
+            key: 3,
+            value: None
+        }),
+        None
+    );
+}
+
+#[test]
+fn test_cleanup_methods_miri() {
+    let mut deque: SortedDeque<Vec<TestItem>> = Default::default();
+
+    let item1 = TestItem {
+        key: 1,
+        value: Some(1.try_into().unwrap()),
+    };
+    let item2 = TestItem {
+        key: 2,
+        value: Some(2.try_into().unwrap()),
+    };
+
+    deque.push_back_or_panic(item1);
+    deque.push_back_or_panic(item2);
+
+    assert_eq!(deque.remove(&item2), Some(item2));
+    deque.cleanup_back();
+
+    assert_eq!(deque.last(), Some(&item1));
+    assert_eq!(deque.find(&item2), None);
+}


### PR DESCRIPTION
We want a FIFO queue with contiguous elements (OSes work with arrays of iovecs, not the pair of arrays of iovs we get from a regular VecDeque).  Waste some space to keep everything contiguous and only memmove over consumed space periodically, with a `SlidingDeque`.

We also want a sorted copntainer that's mostly treated like a FIFO queue with random reads.  We expect that container to mostly be small; the `SortedDeque` gives us that, on top of `SmallVec`.

Start reading at `sliding_deque`: `sorted_deque` builds on top of it.