### PR TITLE
Add owning_iovec crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 
 members = [
+  "owning_iovec",
   "sliding_deque",
 ]
 

--- a/owning_iovec/Cargo.toml
+++ b/owning_iovec/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "owning_iovec"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+sliding_deque = { path = "../sliding_deque" }
+smallvec = "1"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"  # for `struct iovec`
+
+[lints]
+workspace = true

--- a/owning_iovec/src/byte_arena/alloc_cache.rs
+++ b/owning_iovec/src/byte_arena/alloc_cache.rs
@@ -1,0 +1,206 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
+use std::io::IoSlice;
+use std::mem::MaybeUninit;
+use std::ops::Range;
+use std::sync::Arc;
+
+use super::anchor::Anchor;
+use super::anchor::Chunk;
+use super::ioslice;
+
+/// An [`AllocCache`] is a bump pointer in a range of pre-allocated
+/// [`MaybeUninit<u8>`].
+///
+/// Whenever `AllocCache` returns a slice, it also ensures an
+/// [`Anchor`] is responsible for keeping the slice's backing memory
+/// alive.
+#[derive(Debug)]
+pub struct AllocCache {
+    bump: *mut MaybeUninit<u8>,
+    range: Range<*mut MaybeUninit<u8>>, // XXX: redundant with `backing`.
+    backing: Arc<Chunk>,                // Backing memory for `AllocCache`.
+}
+
+// AllocCache is thread-compatible
+unsafe impl Send for AllocCache {}
+unsafe impl Sync for AllocCache {}
+
+impl AllocCache {
+    /// Returns a fresh [`AllocCAche`] that has capacity at least equal to `wanted`,
+    /// and equal to `hint` if possible.
+    #[must_use]
+    pub fn new(wanted: usize, hint: usize) -> AllocCache {
+        let capacity = hint.max(wanted);
+        assert!(capacity >= wanted);
+        let mut storage = Vec::<MaybeUninit<u8>>::with_capacity(capacity);
+        // SAFETY: MaybeUninit is always "initialised"
+        unsafe { storage.set_len(capacity) };
+        let mut chunk = Chunk::new(storage.into_boxed_slice());
+        let range = chunk.as_mut_ptr_range();
+
+        AllocCache {
+            bump: range.start,
+            range,
+            backing: Arc::new(chunk),
+        }
+    }
+
+    /// Returns the initial capacity allocated for the backing chunk
+    /// (i.e., the size of the backing chunk).
+    #[must_use]
+    #[inline(always)]
+    pub fn initial_size(&self) -> usize {
+        (self.range.end as usize) - (self.range.start as usize)
+    }
+
+    /// Returns the address range for the backing chunk.
+    #[must_use]
+    #[inline(always)]
+    pub fn range(&self) -> Range<usize> {
+        Range {
+            start: self.range.start as usize,
+            end: self.range.end as usize,
+        }
+    }
+
+    /// Returns the address of the next allocationn (one past the
+    /// end of the most recent allocation).
+    #[must_use]
+    #[inline(always)]
+    pub fn next_alloc_address(&self) -> usize {
+        self.bump as usize
+    }
+
+    /// Returns the amount of space remaining in the backing chunk.
+    #[must_use]
+    #[inline(always)]
+    pub fn remaining(&self) -> usize {
+        assert!(self.range.start <= self.bump);
+        assert!(self.bump <= self.range.end);
+        let bump = self.bump as usize;
+        let end = self.range.end as usize;
+
+        assert!(bump <= end);
+        end - bump
+    }
+
+    /// Allocates `wanted > 0` bytes and either makes `old_anchor`
+    /// hold onto the returned slice's backing memory, or returns
+    /// a fresh [`Anchor`].
+    ///
+    /// The caller *must* ensure `self.remaining() >= wanted` before
+    /// calling this method.
+    ///
+    /// The `'static` lifetime on the slice is a lie; it lives as
+    /// long as either `old_anchor`, or `anchor`.
+    #[must_use]
+    #[inline(always)]
+    pub unsafe fn alloc_or_die(
+        &mut self,
+        wanted: usize,
+        old_anchor: Option<&mut Anchor>,
+    ) -> (IoSlice<'static>, Option<Anchor>) {
+        assert!(self.range.start <= self.bump);
+        assert!(self.bump <= self.range.end);
+
+        let bump = self.bump as usize;
+        let end = self.range.end as usize;
+        assert!(end - bump >= wanted);
+
+        // SAFETY: bump + wanted <= end
+        let ret = ioslice::make_ioslice(self.bump as *mut u8, wanted);
+        self.bump = unsafe { self.bump.add(wanted) };
+
+        // Avoid cloning `self.backing` if possible.
+        let anchor = Anchor::merge_ref_or_create(old_anchor, &self.backing);
+        (ret, anchor)
+    }
+
+    /// Marks the bytes in `remainder` as available for new allocations.
+    ///
+    /// This `remainder` slice must come from allocation cache and stop
+    /// right at the current bump pointer.
+    pub fn release_or_die(&mut self, remainder: IoSlice<'_>) {
+        let (base, len) = ioslice::ioslice_components(remainder);
+        let addr = base as usize;
+        let end_addr = addr + len;
+
+        // The start address must be strictly in the backing chunk, unless
+        // we have an empty remainder (at the tail of the chunk).
+        assert!(self.range().contains(&addr) | remainder.is_empty());
+        assert_eq!(self.bump as usize, end_addr);
+
+        // SAFETY: `remainder` is fully in the backing chunk.
+        self.bump = unsafe { self.bump.sub(len) };
+    }
+}
+
+#[test]
+fn test_new_miri() {
+    let cache = AllocCache::new(10, 20);
+    assert_eq!(cache.initial_size(), 20);
+    assert_eq!(cache.remaining(), 20);
+}
+
+#[test]
+fn test_alloc_or_die_miri() {
+    let mut cache = AllocCache::new(10, 20);
+    let (slice, anchor) = unsafe { cache.alloc_or_die(5, None) };
+    assert_eq!(slice.len(), 5);
+    assert!(anchor.is_some());
+    assert_eq!(cache.remaining(), 15);
+}
+
+#[test]
+fn test_release_or_die_miri() {
+    let mut cache = AllocCache::new(10, 20);
+    let (slice, _anchor) = unsafe { cache.alloc_or_die(5, None) };
+    cache.release_or_die(slice);
+    assert_eq!(cache.remaining(), 20);
+}
+
+#[test]
+fn test_release_or_die_empty_miri() {
+    let mut cache = AllocCache::new(20, 20);
+    let (slice, _anchor) = unsafe { cache.alloc_or_die(20, None) };
+    cache.release_or_die(IoSlice::new(&slice[20..]));
+    assert_eq!(cache.remaining(), 0);
+}
+
+#[test]
+fn test_alloc_and_release_miri() {
+    let mut cache = AllocCache::new(10, 20);
+    let (slice1, anchor1) = unsafe { cache.alloc_or_die(5, None) };
+    let (slice2, _anchor2) = unsafe { cache.alloc_or_die(10, Some(&mut anchor1.unwrap())) };
+    assert_eq!(slice1.len(), 5);
+    assert_eq!(slice2.len(), 10);
+    assert_eq!(cache.remaining(), 5);
+    cache.release_or_die(slice2);
+    assert_eq!(cache.remaining(), 15);
+}
+
+#[test]
+#[should_panic(expected = "end - bump >= wanted")]
+fn test_alloc_too_large_miri() {
+    let mut cache = AllocCache::new(10, 20);
+    let _result = unsafe { cache.alloc_or_die(21, None) };
+}
+
+#[test]
+#[should_panic(expected = "assertion failed")]
+fn test_release_invalid_slice_miri() {
+    let mut cache = AllocCache::new(10, 20);
+    let mut vec = Vec::with_capacity(5);
+
+    // Assume init to make clippy happy. Hopefully MIRI
+    // can still see that it wasn't actually initialised:
+    // we shouldn't read from the bad slice.
+    for slot in vec.spare_capacity_mut() {
+        unsafe { slot.assume_init_mut() };
+    }
+    unsafe { vec.set_len(5) };
+
+    let slice = IoSlice::new(&vec);
+    cache.release_or_die(slice);
+}

--- a/owning_iovec/src/byte_arena/anchor.rs
+++ b/owning_iovec/src/byte_arena/anchor.rs
@@ -1,0 +1,156 @@
+//! Allocations in a `ByteArena` consist of `u8` slices kept alive by an [`Anchor`].
+//! Each anchor contains an [`Arc<Chunk>`], which keeps a backing allocation
+//! alive.  One [`Arc`] per allocation would be wasteful, so each [`Anchor`]
+//! may be responsible for any number of slices.
+//!
+//! The relationship between slices and [`Anchor`]s is hard to express
+//! in Rust, so we instead expose an unsafe *internal* interface with
+//! `&'static` slices, and wrap in the simpler `OwningIovec`.
+
+use std::mem::MaybeUninit;
+use std::num::NonZeroUsize;
+use std::ptr::NonNull;
+use std::sync::atomic::AtomicUsize;
+use std::sync::Arc;
+
+pub static NUM_LIVE_CHUNKS: AtomicUsize = AtomicUsize::new(0);
+pub static NUM_LIVE_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+/// Conceptually, [`Chunk`] is a `Box<[u8]>`, but we convert to/from
+/// [`NonNull`] at construction and destruction in order to avoid
+/// aliasing footguns.
+#[derive(Debug)]
+pub struct Chunk {
+    storage: NonNull<[MaybeUninit<u8>]>,
+}
+
+impl Chunk {
+    #[must_use]
+    pub fn new(storage: Box<[MaybeUninit<u8>]>) -> Chunk {
+        use std::sync::atomic::Ordering;
+        NUM_LIVE_CHUNKS.fetch_add(1, Ordering::Relaxed);
+        NUM_LIVE_BYTES.fetch_add(storage.len(), Ordering::Relaxed);
+
+        Chunk {
+            storage: NonNull::from(Box::leak(storage)),
+        }
+    }
+
+    #[must_use]
+    #[inline(always)]
+    pub fn as_mut_ptr_range(&mut self) -> std::ops::Range<*mut MaybeUninit<u8>> {
+        unsafe { self.storage.as_mut() }.as_mut_ptr_range()
+    }
+}
+
+// We don't use the raw pointer until it's time to `Drop`.
+unsafe impl Send for Chunk {}
+unsafe impl Sync for Chunk {}
+
+impl Drop for Chunk {
+    fn drop(&mut self) {
+        use std::sync::atomic::Ordering;
+
+        let storage = unsafe { Box::from_raw(self.storage.as_mut()) };
+        let capacity = storage.len();
+        std::mem::drop(storage);
+
+        NUM_LIVE_CHUNKS.fetch_sub(1, Ordering::Relaxed);
+        NUM_LIVE_BYTES.fetch_sub(capacity, Ordering::Relaxed);
+    }
+}
+
+/// Each [`Anchor`] keeps a chunk of backing memory alive on behalf of a
+/// number of allocations.
+#[derive(Clone, Debug, Default)]
+pub struct Anchor {
+    count: usize,              // Number of slices that are backed by this [`Anchor`]
+    chunk: Option<Arc<Chunk>>, // Sticky once populated
+}
+
+impl Anchor {
+    /// Constructs a fresh anchor with a strictly positive use count.  The
+    /// positive `count` isn't a requirement, and the value *will* hit zero
+    /// during normal operations, but it's usually a programming mistake to
+    /// initialise an [`Anchor`] with a zero (ref) count.
+    #[must_use]
+    #[inline(always)]
+    fn new(count: NonZeroUsize, chunk: Arc<Chunk>) -> Self {
+        Anchor {
+            count: count.into(),
+            chunk: Some(chunk),
+        }
+    }
+
+    /// Constructs a fresh anchor with no backing chunk.
+    ///
+    /// An anchor may start out with no backing chunk when it's used to
+    /// represent the ownership of borrowed slices.  It's safe to attach a
+    /// chunk to an `Anchor` after the fact: in the worst case, this only
+    /// extends the chunk's lifetime.  That's why it's also safe to increment
+    /// `count` when a borrowed slice is attached to an [`Anchor`].
+    #[must_use]
+    #[inline(always)]
+    pub fn new_with_count(count: NonZeroUsize) -> Self {
+        Anchor {
+            count: count.into(),
+            chunk: None,
+        }
+    }
+
+    /// Returns the number of slices backed by this `Anchor`.
+    #[must_use]
+    #[inline(always)]
+    pub fn count(&self) -> usize {
+        self.count
+    }
+
+    /// Increments the number of slices backed by this `Anchor`.
+    #[inline(always)]
+    pub fn increment_count(&mut self) {
+        self.count += 1
+    }
+
+    /// Decrements the internal (reference) count by up to `decrement`:
+    /// the `count` value stops at 0.
+    ///
+    /// Returns the extra value in `decrement` that could not be
+    /// subtracted from `count`.
+    #[inline(always)]
+    pub fn decrement_count(&mut self, decrement: usize) -> usize {
+        let can_take = self.count.min(decrement);
+        self.count -= can_take;
+        decrement - can_take
+    }
+
+    /// Determins whether this [`Anchor`] holds on to the same
+    /// [`Chunk`] as `chunk`.
+    #[must_use]
+    #[inline(always)]
+    fn is_same_chunk(&self, chunk: &Arc<Chunk>) -> bool {
+        match self.chunk.as_ref() {
+            Some(this) => Arc::ptr_eq(this, chunk),
+            None => false,
+        }
+    }
+
+    /// Increments `count` in `anchor` if it's populated and matches `chunk`.
+    ///
+    /// Returns a fresh anchor otherwise.
+    #[must_use]
+    pub fn merge_ref_or_create(anchor: Option<&mut Self>, chunk: &Arc<Chunk>) -> Option<Self> {
+        let success = match anchor {
+            Some(anchor) if anchor.is_same_chunk(chunk) => {
+                anchor.count += 1;
+                true
+            }
+            _ => false,
+        };
+
+        if success {
+            None
+        } else {
+            Some(Anchor::new(NonZeroUsize::new(1).unwrap(), chunk.clone()))
+        }
+    }
+}

--- a/owning_iovec/src/byte_arena/mod.rs
+++ b/owning_iovec/src/byte_arena/mod.rs
@@ -1,0 +1,621 @@
+//! A `byte_arena` is an arena for [`[u8]`] slices.  It is very
+//! closely inspired by rustc's `DroplessArena`, except that multiple
+//! arenas can share the share underlying backing store (but
+//! allocation caches are private).
+//!
+//! It is only meant for internal use, and lies by returning `'static`
+//! lifetime values. The only user, `OwningIovec`, guarantees that the
+//! returned allocations don't outlive the arena's backing store.
+#![deny(unsafe_op_in_unsafe_fn)]
+mod alloc_cache;
+mod anchor;
+
+use std::io::IoSlice;
+use std::io::Read;
+use std::num::NonZeroUsize;
+use std::sync::atomic::Ordering;
+
+use super::ioslice;
+use alloc_cache::AllocCache;
+pub use anchor::Anchor;
+
+/// A [`ByteArena`] manages allocation caches (bump pointer regions).
+///
+/// While a default-constructed [`ByteArena`] is valid (and does not
+/// allocate anything ahead of time), they're usually obtained through
+/// [`super::ConsumingIovec::take_arena`].
+#[derive(Debug, Default)]
+pub struct ByteArena {
+    cache: Option<AllocCache>,
+}
+
+/// An [`AnchoredSlice`] is a slice of `[u8`] backed by an internal
+/// refcounted allocation.
+///
+/// It's usually obtained by calling [`ByteArena::read_n`], but the
+/// default value is a valid empty slice.
+#[derive(Clone, Debug)]
+pub struct AnchoredSlice {
+    slice: IoSlice<'static>, // actually lives as long as `anchor`.
+    anchor: Anchor,
+}
+
+impl Default for AnchoredSlice {
+    #[inline(always)]
+    fn default() -> Self {
+        const EMPTY: [u8; 0] = [];
+
+        Self {
+            slice: ioslice::make_ioslice(EMPTY.as_ptr() as *mut _, 0),
+            anchor: Default::default(),
+        }
+    }
+}
+
+impl Clone for ByteArena {
+    #[inline(always)]
+    fn clone(&self) -> ByteArena {
+        // Can't clone the `AllocCache`.
+        Default::default()
+    }
+}
+
+/// We try to allocate chunks from this geometrically growing size sequence..
+const BUMP_REGION_SIZE_SEQUENCE: [usize; 9] = [
+    1 << 12,
+    1 << 13,
+    1 << 14,
+    1 << 15,
+    1 << 16,
+    1 << 17,
+    1 << 18,
+    1 << 19,
+    1 << 20,
+];
+
+/// We round to 4KB
+const BUMP_REGION_SIZE_FACTOR: usize = 4096;
+
+// Whenever we allocate from a [`ByteArena`], the allocation is associated
+// with an `Anchor`.  Each anchor has a sticky optional reference to the
+// backing chunk; when all anchors (and the allocation cache) are dropped,
+// the backing memory automatically released.  The [`std::sync::Arc`] in
+// `Anchor` is heavy-weight, so each may stand for multiple allocations.
+//
+// The relationship between `Anchor`s and [`ByteArena`] allocations isn't
+// easy to express in the Rust typesystem, so we instead expose an unsafe
+// interface; this type is only expected to be used via [`crate::OwningIovec`].
+
+impl ByteArena {
+    /// Creates a fresh arena, with a fresh backing store.
+    #[must_use]
+    #[inline(always)]
+    pub fn new() -> ByteArena {
+        Default::default()
+    }
+
+    /// Returns the current number of live (allocated, not yet freed)
+    /// backing arena chunks for all [`ByteArena`] in the process.
+    #[must_use]
+    pub fn num_live_chunks() -> usize {
+        anchor::NUM_LIVE_CHUNKS.load(Ordering::Relaxed)
+    }
+
+    /// Returns the total size in bytes of live (allocated, not yet freed)
+    /// backing arena chunks for all [`ByteArena`] in the process.
+    #[must_use]
+    pub fn num_live_bytes() -> usize {
+        anchor::NUM_LIVE_BYTES.load(Ordering::Relaxed)
+    }
+
+    /// Flushes the arena's internal allocation cache.
+    #[inline(never)] // The destructor can turn into a lot of code.
+    pub fn flush_cache(&mut self) {
+        self.cache = None;
+    }
+
+    /// Returns the number of bytes left in the current allocation cache.
+    #[must_use]
+    #[inline(always)]
+    pub fn remaining(&self) -> usize {
+        match &self.cache {
+            Some(cache) => cache.remaining(),
+            None => 0,
+        }
+    }
+
+    /// Determines whether `slice` was the last slice allocated by the
+    /// [`ByteArena`]'s current allocation cache.
+    #[must_use]
+    #[inline(always)]
+    pub fn is_last(&self, slice: IoSlice<'_>) -> bool {
+        match &self.cache {
+            Some(cache) => {
+                unsafe { self.contains(slice) }.is_some()
+                    & (slice.as_ptr_range().end as usize == cache.next_alloc_address())
+            }
+            None => false,
+        }
+    }
+
+    /// Ensure the current allocation cache has room for at least `len` bytes.
+    #[inline(always)]
+    pub fn ensure_capacity(&mut self, len: usize) {
+        self.ensure_capacity_internal(len);
+    }
+
+    #[inline(never)]
+    fn ensure_capacity_internal(&mut self, len: usize) -> &mut AllocCache {
+        let (ok, initial_size) = match self.cache.as_mut() {
+            Some(cache) => {
+                let initial_size = cache.initial_size();
+                (cache.remaining() >= len, initial_size)
+            }
+            None => (false, 0),
+        };
+
+        if ok {
+            // We just checked that the cache is non-empty and has enough room.
+            self.cache.as_mut().unwrap()
+        } else {
+            // Drop the old one before allocating a new cache.
+            self.cache = None;
+
+            // Find the "ideal" size if we have to allocate fresh.
+            let hint = Self::find_hint_size(len, initial_size);
+            let cache = AllocCache::new(len, hint);
+            assert!(cache.remaining() >= len);
+            self.cache.insert(cache)
+        }
+    }
+
+    /// Find the "ideal" chunk size if we have to allocate a fresh chunk.
+    fn find_hint_size(len: usize, prev_capacity: usize) -> usize {
+        let max_size_sequence = *BUMP_REGION_SIZE_SEQUENCE.last().unwrap();
+
+        if len >= max_size_sequence {
+            // We're asking a large capacity, just round that up to a multiple of BUMP_REGION_SIZE_FACTOR
+            let hint = len
+                .div_ceil(BUMP_REGION_SIZE_FACTOR)
+                .saturating_mul(BUMP_REGION_SIZE_FACTOR);
+            assert!(hint >= len);
+            return hint;
+        }
+
+        if prev_capacity >= max_size_sequence {
+            // We're already at the max size, stay there.
+            assert!(len < max_size_sequence);
+
+            let hint = max_size_sequence;
+            assert!(hint >= len);
+            return hint;
+        }
+
+        // len < max_size_sequence, initial_size < max_size_sequence
+        let wanted = prev_capacity.saturating_add(1).max(len);
+        assert!(wanted <= max_size_sequence);
+
+        // Default to `max_size_sequence`
+        let mut hint = max_size_sequence;
+        // But try to find the first element in the size sequence that's at least equal to `wanted`.
+        for size in BUMP_REGION_SIZE_SEQUENCE {
+            if size >= wanted {
+                hint = size;
+                break;
+            }
+        }
+
+        assert!(hint >= len);
+        // We must grow if we get here.
+        assert!(hint > prev_capacity);
+
+        hint
+    }
+
+    /// Checks whether `slice` definitely comes from this [`ByteArena`]'s backing storage.
+    ///
+    /// If so, returns a static lifetime slice.
+    ///
+    /// # Safety
+    ///
+    /// The return value's lifetime is a lie.  This method should only be used in
+    /// `try_join`.
+    #[must_use]
+    #[inline(always)]
+    unsafe fn contains(&self, slice: IoSlice<'_>) -> Option<IoSlice<'static>> {
+        let range = &self.cache.as_ref()?.range();
+        let (iov_base, iov_len) = ioslice::ioslice_components(slice);
+        let base = iov_base as usize;
+        let end = base + iov_len;
+
+        if (range.start <= base) & (end <= range.end) {
+            Some(ioslice::make_ioslice(iov_base, iov_len))
+        } else {
+            None
+        }
+    }
+
+    /// Checks whether `left` and `right` are adjacent subslices that
+    /// definitely come from the same underlying allocation.
+    ///
+    /// If so, returns a static lifetime slice for their concatenation.
+    ///
+    /// # Safety
+    ///
+    /// The return value must not outlast the slices' anchor(s).  The
+    /// static lifetime is a lie.
+    #[must_use]
+    #[inline(always)]
+    pub(crate) unsafe fn try_join(
+        &self,
+        left: IoSlice<'_>,
+        right: IoSlice<'_>,
+    ) -> Option<IoSlice<'static>> {
+        if let (Some(left), Some(right)) = unsafe { (self.contains(left), self.contains(right)) } {
+            let left = ioslice::ioslice_components(left);
+            let right = ioslice::ioslice_components(right);
+            if (left.0 as usize + left.1) == (right.0 as usize) {
+                return Some(ioslice::make_ioslice(left.0, left.1 + right.1));
+            }
+        }
+
+        None
+    }
+
+    /// Internal slow path for `alloc`: we make sure there's capacity for `len`
+    /// bytes and ask for that many.
+    #[inline(never)]
+    fn grow_and_alloc(
+        &mut self,
+        len: usize,
+        old_anchor: Option<&mut Anchor>,
+    ) -> (IoSlice<'static>, Option<Anchor>) {
+        let cache = self.ensure_capacity_internal(len);
+        // we just ensured capacity
+        unsafe { cache.alloc_or_die(len, old_anchor) }
+    }
+
+    /// Allocates a slice of `len` bytes from this [`ByteArena`].
+    ///
+    /// When `old_anchor` is provided and matches the current backing
+    /// chunk, increments its internal allocation count.  Otherwise,
+    /// returns a fresh anchor.
+    ///
+    /// # Safety
+    ///
+    /// The return value must not outlast the `old_anchor` or the new
+    /// anchor.  We lie with `'static` because `OwningIovec` just has
+    /// to get it right.
+    #[must_use]
+    #[inline(always)]
+    pub(crate) unsafe fn alloc(
+        &mut self,
+        len: NonZeroUsize,
+        old_anchor: Option<&mut Anchor>,
+    ) -> (IoSlice<'static>, Option<Anchor>) {
+        // The cache grabs bytes from a slice that belongs to
+        // `self.backing`, so the storage lives at least as long as
+        // the anchor.
+        let len: usize = len.into();
+        if self.remaining() >= len {
+            let cache = self.cache.as_mut().expect("capacity > 0");
+            // we already checked for capacity
+            unsafe { cache.alloc_or_die(len, old_anchor) }
+        } else {
+            self.grow_and_alloc(len, old_anchor)
+        }
+    }
+
+    /// Allocates a copy of `src` from this `ByteArena`.  Panics if
+    /// `src` is empty.
+    ///
+    /// When `old_anchor` is provided and matches the current backing
+    /// chunk, increments its internal allocation count.  Otherwise,
+    /// returns a fresh anchor.
+    ///
+    /// # Safety
+    ///
+    /// The return value must not outlast the `old_anchor` or the new
+    /// anchor.  We lie with `'static` because `OwningIovec` just has
+    /// to get it right.
+    #[must_use]
+    #[inline(always)]
+    pub(crate) unsafe fn copy(
+        &mut self,
+        src: &[u8],
+        old_anchor: Option<&mut Anchor>,
+    ) -> (IoSlice<'static>, Option<Anchor>) {
+        // zero-sized allocation and memcpy have surprising aliasing consequences.
+        assert!(!src.is_empty());
+
+        let (dst, anchor) =
+            unsafe { self.alloc(NonZeroUsize::new(src.len()).unwrap(), old_anchor) };
+
+        let (dst_ptr, len) = ioslice::ioslice_components(dst);
+
+        assert_eq!(len, src.len());
+        unsafe { dst_ptr.copy_from_nonoverlapping(src.as_ptr(), len) };
+
+        (ioslice::make_ioslice(dst_ptr, len), anchor)
+    }
+}
+
+impl AnchoredSlice {
+    /// Returns the anchored data.
+    #[must_use]
+    #[inline(always)]
+    pub fn slice(&self) -> &[u8] {
+        &self.slice
+    }
+
+    /// Swaps `self` with an empty [`AnchoredSlice`] and returns
+    /// the initial `self` slice.
+    #[must_use]
+    #[inline(always)]
+    pub fn take(&mut self) -> AnchoredSlice {
+        let mut ret: AnchoredSlice = Default::default();
+        std::mem::swap(self, &mut ret);
+        ret
+    }
+
+    /// Skips up to the first `count` bytes in the anchored data,
+    /// less if `count` is greater than the data's size.
+    ///
+    /// Returns the number of bytes actually skipped.
+    #[inline(always)]
+    pub fn skip_prefix(&mut self, count: usize) -> usize {
+        let (mut base, mut len) = ioslice::ioslice_components(self.slice);
+
+        let count = count.min(len);
+        base = unsafe { base.add(count) };
+        len -= count;
+        self.slice = ioslice::make_ioslice(base, len);
+        count
+    }
+
+    /// Drops up to the last `count` bytes in the anchored data,
+    /// less if `count` is greater than the data's size.
+    ///
+    /// Returns the number of bytes actually skipped.
+    #[inline(always)]
+    pub fn drop_suffix(&mut self, count: usize) -> usize {
+        let (base, mut len) = ioslice::ioslice_components(self.slice);
+        let count = count.min(len);
+        len -= count;
+        self.slice = ioslice::make_ioslice(base, len);
+        count
+    }
+
+    /// Splits this `AnchoredSlice` in two parts: the first one has the
+    /// first `mid` bytes (or the whole slice), and the second has any
+    /// remaining data.
+    #[must_use]
+    pub fn split_at(self, mid: usize) -> (AnchoredSlice, AnchoredSlice) {
+        let (base, len) = ioslice::ioslice_components(self.slice);
+        if mid >= len {
+            (self, Default::default())
+        } else {
+            let left_slice = ioslice::make_ioslice(base, mid);
+            let right_slice = ioslice::make_ioslice(unsafe { base.add(mid) }, len - mid);
+
+            let left = AnchoredSlice {
+                slice: left_slice,
+                anchor: self.anchor.clone(),
+            };
+            let right = AnchoredSlice {
+                slice: right_slice,
+                anchor: self.anchor,
+            };
+
+            (left, right)
+        }
+    }
+
+    /// Explodes the `AnchoredSlice` in a slice and an anchor.  The slice's
+    /// `static` lifetime is a lie: it really only lives as long as `Anchor`.
+    ///
+    /// # Safety
+    ///
+    /// Calling `AnchoredSlice::components` is safe in itself, but the
+    /// returned slice's lifetime is a lie.  It must never actually
+    /// outlive its `Anchor`.
+    #[must_use]
+    #[inline(always)]
+    pub unsafe fn components(self) -> (IoSlice<'static>, &'static [u8], Anchor) {
+        let (base, len) = ioslice::ioslice_components(self.slice);
+        let slice = unsafe { std::slice::from_raw_parts(base as *const u8, len) };
+        (self.slice, slice, self.anchor)
+    }
+}
+
+impl ByteArena {
+    /// Reads up to `count` bytes from `src`, by making up to `max_attempts` calls
+    /// to `Read::read`.
+    ///
+    /// Returns the resulting slice on success.
+    ///
+    /// This method retries on [`std::io::ErrorKind::Interrupted`] and
+    /// short reads.  It stops at the first error or zero-sized read
+    /// (EOF).  Calls to this method always succeed when at least 1
+    /// byte was read; otherwise, the method returns the last error
+    /// encountered (the first non-`EINTR`, unless it's all `EINTR`).
+    ///
+    /// This method returns `Ok(0)` iff `src.read()` does as well, i.e.,
+    /// on EOF.  A string of `max_attempts` [`std::io::ErrorKind::Interrupted`]
+    /// instead results in returning that as an error.
+    pub fn read_n(
+        &mut self,
+        src: impl Read,
+        count: usize,
+        max_attempts: NonZeroUsize,
+    ) -> std::io::Result<AnchoredSlice> {
+        if count == 0 {
+            return Ok(Default::default());
+        }
+
+        let (raw_slice, anchor) = unsafe { self.alloc(NonZeroUsize::new(count).unwrap(), None) };
+        let (base, len) = ioslice::ioslice_components(raw_slice);
+        assert_eq!(len, count);
+        let slice: &'static mut [u8] = unsafe { std::slice::from_raw_parts_mut(base, count) };
+
+        match self.read_n_impl(src, slice, max_attempts) {
+            Ok(got) => {
+                assert!(got <= count);
+                let got_slice = ioslice::make_ioslice(base, got);
+                let remainder = ioslice::make_ioslice(unsafe { base.add(got) }, count - got);
+                self.cache.as_mut().unwrap().release_or_die(remainder);
+
+                Ok(AnchoredSlice {
+                    slice: got_slice,
+                    anchor: anchor.unwrap_or_default(),
+                })
+            }
+            Err(e) => {
+                // We just got an allocation, the cache isn't empty.
+                self.cache.as_mut().unwrap().release_or_die(raw_slice);
+                Err(e)
+            }
+        }
+    }
+
+    fn read_n_impl(
+        &mut self,
+        mut src: impl Read,
+        slice: &'static mut [u8],
+        max_attempts: NonZeroUsize,
+    ) -> std::io::Result<usize> {
+        slice.fill(0); // XXX: unfortunately...
+        let mut got = 0usize;
+        let mut err: Option<std::io::Error> = None;
+
+        for _ in 0..max_attempts.get() {
+            let ret = src.read(&mut slice[got..]);
+
+            match ret {
+                Ok(count) => {
+                    got += count;
+                    if count == 0 {
+                        // EOF: bail out with Ok(len).
+                        err = None;
+                        break;
+                    }
+                }
+                Err(e) => {
+                    let kind = e.kind();
+                    err.replace(e);
+                    if kind != std::io::ErrorKind::Interrupted {
+                        // Stop at the first real error.
+                        break;
+                    }
+                }
+            }
+
+            if got == slice.len() {
+                break;
+            }
+        }
+
+        match (got, err) {
+            (0, Some(e)) => Err(e),
+            _ => Ok(got),
+        }
+    }
+}
+
+// This is mostly an internal class.  It's really tested through its
+// main user, `owning_iovec`.
+
+// Check that we correctly round up to at least the allocation size,
+// and don't consider the previous capacity when doing so.
+#[test]
+fn test_size_sequence_large_miri() {
+    // Huge allocation -> just round up.
+    assert_eq!(ByteArena::find_hint_size(2_000_000, 4096), 2002944);
+    assert_eq!(2002944, 489 * 4096);
+
+    // Same, regardless of the previous size
+    assert_eq!(
+        ByteArena::find_hint_size(2 * 1024 * 1024, 4_000_000),
+        2 * 1024 * 1024
+    );
+}
+
+// Check that we don't try to grow past the maximum region size when
+// the mandatory size is small.
+#[test]
+fn test_size_sequence_grow_capped_miri() {
+    // Small allocation, but large initial size.  Stay at the max value.
+    let max = *BUMP_REGION_SIZE_SEQUENCE.last().unwrap();
+    assert_eq!(ByteArena::find_hint_size(1, max - 1), max);
+    assert_eq!(ByteArena::find_hint_size(1, max), max);
+    assert_eq!(ByteArena::find_hint_size(4096, 2_000_000), max);
+}
+
+// Check that we grow geometrically.
+#[test]
+fn test_size_sequence_grow_miri() {
+    assert_eq!(
+        ByteArena::find_hint_size(1, 0),
+        *BUMP_REGION_SIZE_SEQUENCE.first().unwrap()
+    );
+
+    let max = *BUMP_REGION_SIZE_SEQUENCE.last().unwrap();
+    for value in BUMP_REGION_SIZE_SEQUENCE.iter().copied() {
+        let hint = ByteArena::find_hint_size(1, value);
+        if value == max {
+            assert_eq!(hint, max);
+        } else {
+            assert!(hint > value);
+            // Growth must be geometric.
+            assert_eq!(hint, 2 * value);
+            assert!(hint <= max);
+        }
+    }
+}
+
+#[test]
+fn test_anchored_slice_miri() {
+    let mut arena = ByteArena::new();
+    let (data, anchor) = unsafe { arena.copy(b"0123456789", None) };
+
+    let mut slice = AnchoredSlice {
+        slice: data,
+        anchor: anchor.unwrap(),
+    };
+
+    assert_eq!(slice.slice(), b"0123456789");
+
+    assert_eq!(slice.skip_prefix(1), 1);
+    assert_eq!(slice.slice(), b"123456789");
+
+    assert_eq!(slice.drop_suffix(1), 1);
+    assert_eq!(slice.slice(), b"12345678");
+
+    let (mut left, right) = slice.split_at(5);
+    assert_eq!(left.slice(), b"12345");
+    assert_eq!(right.slice(), b"678");
+
+    let mut other_left = left.clone();
+
+    // Check that skipping more than the size drops everything.
+    assert_eq!(left.skip_prefix(100), 5);
+    assert_eq!(left.slice(), b"");
+    std::mem::drop(left);
+
+    // Check that dropping more than the size drops everything.
+    assert_eq!(other_left.slice(), b"12345");
+    assert_eq!(other_left.drop_suffix(10), 5);
+    assert_eq!(other_left.slice(), b"");
+    std::mem::drop(other_left);
+
+    // Check that splitting at 0 is a no-op;
+    let (left, right) = right.split_at(0);
+    assert_eq!(left.slice(), b"");
+    std::mem::drop(left);
+    assert_eq!(right.slice(), b"678");
+
+    // Check that splitting past the end is a near no-op.
+    let (right, empty) = right.split_at(1000);
+    assert_eq!(right.slice(), b"678");
+    assert_eq!(empty.slice(), b"");
+}

--- a/owning_iovec/src/global_deque.rs
+++ b/owning_iovec/src/global_deque.rs
@@ -1,0 +1,277 @@
+use std::collections::VecDeque;
+use std::io::IoSlice;
+use std::num::NonZeroUsize;
+
+use sliding_deque::SlidingVec;
+
+use super::byte_arena::Anchor;
+
+/// The `GlobalDeque` is a `SlidingDeque` of `IoSlice` that tracks the
+/// current logical (monotonically increasing) position and size, and
+/// maps between that and the physical locations, taking into account
+/// the `IoSlice`s and bytes consumed.
+///
+/// Each slice is also backed by one [`Anchor`] in `anchors`.  Slices
+/// (and anchors) may be appended to the end of the [`GlobalDeque`],
+/// merged at the end, or consumed from the front.  The caller ([`OwningIovec`])
+/// is responsible for capping consumption if it holds backreferences
+/// into `slices`.
+///
+/// The usage of the `this` lifetime can be unsound; we rely on constraints
+/// on the surrounding [`OwningIovec`] to avoid dangling slices.
+#[derive(Debug, Default, Clone)]
+pub struct GlobalDeque<'this> {
+    slices: SlidingVec<IoSlice<'this>>,
+    anchors: VecDeque<Anchor>, // Each anchor is responsible for a contiguous number (> 0) of slices.
+    logical_size: u64,
+    consumed_size: u64,
+    consumed_slices: u64,
+}
+
+impl<'this> GlobalDeque<'this> {
+    #[must_use]
+    pub fn new(slices: Vec<IoSlice<'this>>) -> Self {
+        let logical_size = slices.iter().map(|slice| slice.len() as u64).sum();
+        let mut anchors = VecDeque::new();
+
+        if !slices.is_empty() {
+            let count = NonZeroUsize::new(slices.len()).expect("slices isn't empty");
+            anchors.push_back(Anchor::new_with_count(count));
+        }
+
+        GlobalDeque {
+            slices: slices.into(),
+            anchors,
+            logical_size,
+            consumed_size: 0,
+            consumed_slices: 0,
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.slices.clear();
+        self.anchors.clear();
+        self.logical_size = 0;
+        self.consumed_size = 0;
+        self.consumed_slices = 0;
+    }
+
+    /// Pushes a new slice at the end of the deque.  If we have an anchor
+    /// it's pushed to the back of the anchor deque; otherwise, we assume
+    /// the current last anchor has been mutated in place to take the
+    /// new slice into account.
+    pub fn push(&mut self, entry: (IoSlice<'this>, Option<Anchor>)) {
+        let (slice, anchor) = entry;
+
+        // This shouldn't happen, but it doesn't hurt to be defensive:
+        // consumers want to assume there are no empty slices.
+        #[cfg(not(test))]
+        if slice.is_empty() {
+            return;
+        }
+
+        assert!(!slice.is_empty());
+
+        self.logical_size += slice.len() as u64;
+        self.slices.push_back(slice);
+        if let Some(anchor) = anchor {
+            self.anchors.push_back(anchor);
+        } else {
+            assert!(!self.anchors.is_empty());
+        }
+    }
+
+    /// Pushes a borrowed slice (guaranteed to outlive the `GlobalDeque`)
+    /// at the end of the deque.
+    pub fn push_borrowed(&mut self, slice: IoSlice<'this>) {
+        #[cfg(not(test))]
+        if slice.is_empty() {
+            return;
+        }
+
+        assert!(!slice.is_empty());
+
+        self.logical_size += slice.len() as u64;
+        self.slices.push_back(slice);
+
+        if self.anchors.is_empty() {
+            self.anchors.push_back(Default::default());
+        }
+
+        self.anchors.back_mut().unwrap().increment_count();
+    }
+
+    #[inline(always)]
+    pub fn push_anchor(&mut self, mut anchor: Anchor) {
+        anchor.decrement_count(anchor.count());
+        self.anchors.push_back(anchor);
+    }
+
+    #[must_use]
+    #[inline(always)]
+    pub fn last_anchor(&mut self) -> Option<&mut Anchor> {
+        self.anchors.back_mut()
+    }
+
+    #[must_use]
+    #[inline(always)]
+    pub fn last_slice(&self) -> Option<IoSlice<'this>> {
+        self.slices.last().copied()
+    }
+
+    #[must_use]
+    #[inline(always)]
+    pub fn logical_size(&self) -> u64 {
+        self.logical_size
+    }
+
+    #[must_use]
+    #[inline(always)]
+    pub fn last_logical_slice_index(&self) -> u64 {
+        self.consumed_slices + (self.slices.len() as u64) - 1
+    }
+
+    #[must_use]
+    #[inline(always)]
+    pub fn get_logical_slice(&self, index: u64) -> Option<IoSlice<'this>> {
+        let index = index
+            .wrapping_sub(self.consumed_slices)
+            .min(usize::MAX as u64) as usize;
+
+        self.slices.get(index).copied()
+    }
+
+    /// Gets the prefix of slices we can look at *before* the logical slice index
+    /// `end_logical_slice`.
+    #[inline(always)]
+    pub fn get_logical_prefix(&self, end_logical_slice: Option<u64>) -> &[IoSlice<'this>] {
+        let end_logical_slice = end_logical_slice.unwrap_or(u64::MAX);
+        let remainder = end_logical_slice - self.consumed_slices;
+        let take = remainder.min(self.slices.len() as u64) as usize;
+
+        &self.slices[..take]
+    }
+
+    /// Drops the first `count` slices in the deque.
+    #[inline(never)]
+    pub fn consume(&mut self, count: usize) -> usize {
+        let count = count.min(self.slices.len());
+
+        let consumed_size: u64 = self.slices[..count]
+            .iter()
+            .map(|slice| slice.len() as u64)
+            .sum();
+        self.consumed_size += consumed_size;
+        self.consumed_slices += count as u64;
+
+        let consumed = self.slices.advance(count);
+        assert_eq!(consumed, count);
+
+        let mut num_to_drain = consumed;
+        while num_to_drain > 0 {
+            let front = self
+                .anchors
+                .front_mut()
+                .expect("must have front if we consumed some slices");
+            num_to_drain = front.decrement_count(num_to_drain);
+            if front.count() == 0 {
+                // We made progress!
+                self.anchors.pop_front();
+            } else {
+                // Or we're done.
+                assert_eq!(num_to_drain, 0);
+            }
+        }
+
+        // Drop any zero-count anchor at the front.
+        while let Some(anchor) = self.anchors.front() {
+            if anchor.count() > 0 {
+                break;
+            }
+
+            self.anchors.pop_front();
+        }
+
+        // slices js empty iff anchors are as well.
+        assert!(self.slices.is_empty() == self.anchors.is_empty());
+
+        count
+    }
+
+    /// Drops the first `count` bytes in the deque.  Any partially consumed
+    /// final slice is advanced in place.
+    #[inline(never)]
+    pub fn consume_by_bytes(&mut self, count: usize) -> usize {
+        let mut consumed = 0;
+
+        while consumed < count {
+            let slice = self
+                .slices
+                .front_mut()
+                .expect("OwningIovec bound-checks upstream");
+
+            let len = slice.len();
+            let num_to_consume = (count - consumed).min(slice.len());
+            let ptr = slice.as_ptr();
+
+            let new_slice = unsafe {
+                std::slice::from_raw_parts(ptr.add(num_to_consume), len - num_to_consume)
+            };
+            if new_slice.is_empty() {
+                // XXX: should we consume the full sized slices in bulk?
+                self.consume(1);
+            } else {
+                *slice = IoSlice::new(new_slice);
+                self.consumed_size += num_to_consume as u64;
+                assert_eq!(num_to_consume, count - consumed);
+            }
+
+            consumed += num_to_consume;
+        }
+
+        consumed
+    }
+
+    /// Returns the total number of slices.
+    #[must_use]
+    #[inline(always)]
+    pub fn num_slices(&self) -> usize {
+        self.slices.len()
+    }
+
+    /// Returns the total number of bytes in the slices.
+    #[must_use]
+    #[inline(always)]
+    pub fn total_size(&self) -> usize {
+        (self.logical_size - self.consumed_size) as usize
+    }
+
+    /// Attempts to collapse the last two slices in the deque into a
+    /// single slice, if it's safe to do so.
+    pub fn maybe_collapse_last_pair(
+        &mut self,
+        collapse: impl FnOnce(IoSlice<'this>, IoSlice<'this>) -> Option<IoSlice<'this>>,
+    ) {
+        let len = self.slices.len();
+        if len < 2 {
+            return;
+        }
+
+        let anchor = self
+            .anchors
+            .back_mut()
+            .expect("must have anchor for slices");
+        assert!(anchor.count() > 0);
+        if anchor.count() < 2 {
+            return;
+        }
+
+        if let Some(merger) = collapse(self.slices[len - 2], self.slices[len - 1]) {
+            self.slices.pop_back();
+            *self.slices.back_mut().unwrap() = merger;
+            // We can only collapse when the two slices are from the same
+            // chunk, so we only had one for both anchor.
+            anchor.decrement_count(1);
+        }
+    }
+}

--- a/owning_iovec/src/implementation.rs
+++ b/owning_iovec/src/implementation.rs
@@ -1,0 +1,992 @@
+use std::io::IoSlice;
+use std::num::NonZeroUsize;
+
+use sliding_deque::SortedDeque;
+use smallvec::SmallVec;
+
+use super::byte_arena::Anchor;
+use super::byte_arena::ByteArena;
+use super::global_deque::GlobalDeque;
+use super::ioslice;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct BackrefInfo {
+    slice_index: u64,  // Global iov index
+    begin: usize,      // Range in the target iov
+    len: NonZeroUsize, // Size of the range
+}
+
+/// Each [`Backref`] represents a capability to
+/// backfill some bytes owned by an [`OwningIovec`].
+///
+/// They are returned by [`OwningIovec::register_patch`], and
+/// backfilled by [`OwningIovec::backfill`].  Backreference are not
+/// clonable, so cloning an `OwningIovec` that has in-flight
+/// backreferences isn't super useful.
+///
+/// A default-constructed [`Backref`] represents a 0-sized
+/// backpatch.
+#[derive(Debug, Default)]
+#[repr(transparent)]
+#[must_use]
+pub struct Backref(Option<(u64, BackrefInfo)>);
+
+impl Backref {
+    /// Returns the number of bytes in the backref
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.0.map(|(_, info)| info.len.into()).unwrap_or(0)
+    }
+
+    /// Determines whether the backref spans 0 bytes.  In practice,
+    /// we don't expect to generate empty backreferences.
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+type ErasableBackrefInfo = (u64, Option<BackrefInfo>);
+
+/// An [`OwningIovec`] is a [`Vec<IoSlice<>>`] that may optionally own
+/// some of it slices' pointees.  Some of the owned pointees may be
+/// backpatched after the fact, and it's possible to peek at and consume
+/// the first `IoSlice`s that aren't waiting for a backpatch.
+///
+/// Internally, owned slices are allocated from an internal arena
+/// with `Arc` to the backing allocations tracked internally.
+#[derive(Debug, Default, Clone)]
+pub struct OwningIovec<'this> {
+    // The `GlobalDeque` manages the mapping between slices and
+    // Anchors, but is oblivious to backreferences.  Always bound
+    // check *that* before accessing `slices`.
+    //
+    // XXX: we internally guarantee to never push empty slices in
+    // there, and the global deque itself skips empty slices.
+    slices: GlobalDeque<'this>,
+
+    // We allocate from `arena`, but only to stick values in `iovs`,
+    // and this `ByteArena` is static for the lifetime of the
+    // `OwningIovec`.
+    arena: ByteArena,
+
+    // The first value is the key, the logical byte index of the
+    // backreference in the [`GlobalDeque`], and the second value
+    // if the info, if the backref is still in flight (None when
+    // logically deleted).
+    backrefs: SortedDeque<SmallVec<[ErasableBackrefInfo; 4]>>, // Pending backrefs
+}
+
+/// [`ConsumingIovec`] is a mutable reference to an [`OwningIovec`]
+/// that only exposes consuming operations (i.e., can't put slices
+/// in).  It can also be derefed as a const ref to [`OwningIovec`],
+/// for read-only methods.  The 'a lifetime stands for the inner
+/// `OwningIovec`'s lifetime, which must not exceed the slice's.
+///
+/// This dataflow means we only want covariance (like regular references).
+#[derive(Debug)]
+#[repr(transparent)]
+// We do not need a PhantomData<OwningIovec<'a>> because `ConsumingIovec`
+// does not own the `OwningIovec` (and further `OwningIovec` does not
+// look at the 'life-slices' contents when it drops).
+// (https://github.com/rust-lang/rfcs/blob/master/text/0769-sound-generic-drop.md#phantom-data).
+//
+// NonNull is safe because we do want covariance in 'a.
+pub struct ConsumingIovec<'a>(std::ptr::NonNull<OwningIovec<'a>>);
+
+/// A [`StableIovec`] is a [`ConsumingIovec`] constructed from an
+/// [`OwningIovec`] that does not have any backreference in flight.
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct StableIovec<'a>(ConsumingIovec<'a>);
+
+impl<'slices> ConsumingIovec<'slices> {
+    /// ConsumingIovec does not implement Clone, and iovec accepts a
+    /// mutable reference, so this internal pointer must be an
+    /// exclusive reference to the pointee.  It's safe to convert back
+    /// to &mut, because this wrapper acts like &mut &mut.
+    ///
+    /// We know the `OwningIovec` itself is only safe to keep around
+    /// for `'a`.  We also know the slices' lifetime is at least as wide,
+    /// so we force them to `'a` too; there's no lost functionality
+    /// because read-side methods restrict the slices' lifetime to the
+    /// same as the `OwningIovec` (to take into account owned slices).
+    #[must_use]
+    #[inline(always)]
+    fn iovec<'this>(&'this mut self) -> &'this mut OwningIovec<'slices>
+    where
+        'slices: 'this, // slices must outlive this for NonNull, but let's be explicit.
+    {
+        unsafe { self.0.as_mut() }
+    }
+}
+
+impl<'a> std::convert::From<&'a mut OwningIovec<'_>> for ConsumingIovec<'a> {
+    // It's important to constraint the `&mut OwningIovec` with `'a`:
+    // the slices can have an arbitrary wider lifetime than the OwningIovec,
+    // (e.g., `OwningIovec<'static>`).  For reading purposes, it's safe
+    // to narrow the slices' lifetime to the same `'a` as the iovec:
+    // we only borrow/copy slices out of the iovec, and all const methods
+    // force the output slices' lifetime to match the iovec's.
+    #[inline(always)]
+    fn from(iovec: &'a mut OwningIovec<'_>) -> ConsumingIovec<'a> {
+        ConsumingIovec(iovec.into())
+    }
+}
+
+/// A [`ConsumingIovec`] can be converted to a [`StableIovec`] if
+/// there are no backref in flight;  otherwise, the input [`ConsumingIovec`]\
+/// is returned back as the error.
+impl<'a> std::convert::TryFrom<ConsumingIovec<'a>> for StableIovec<'a> {
+    type Error = ConsumingIovec<'a>;
+
+    #[inline(always)]
+    fn try_from(iovec: ConsumingIovec<'a>) -> Result<StableIovec<'a>, ConsumingIovec<'a>> {
+        if iovec.has_pending_backrefs() {
+            Err(iovec)
+        } else {
+            Ok(StableIovec(iovec))
+        }
+    }
+}
+
+// No DerefMut because the whole point of `ConsumingIovec` is to
+// only allow the consuming subset of mutable methods.
+impl<'a> std::ops::Deref for ConsumingIovec<'a> {
+    type Target = OwningIovec<'a>;
+
+    #[inline(always)]
+    fn deref(&self) -> &OwningIovec<'a> {
+        unsafe { self.0.as_ref() }
+    }
+}
+
+impl<'a> std::ops::Deref for StableIovec<'a> {
+    type Target = ConsumingIovec<'a>;
+
+    #[inline(always)]
+    fn deref(&self) -> &ConsumingIovec<'a> {
+        &self.0
+    }
+}
+
+impl<'a> std::ops::DerefMut for StableIovec<'a> {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut ConsumingIovec<'a> {
+        &mut self.0
+    }
+}
+
+/// Always copy when the source is at most this long.
+const SMALL_COPY: usize = 64;
+
+/// Copy when the source is at most this long and we'd extend the last IoSlice.
+const MAX_OPPORTUNISTIC_COPY: usize = 256;
+
+#[must_use]
+#[inline(always)]
+fn ioslice_len(slice: IoSlice<'_>) -> usize {
+    ioslice::ioslice_components(slice).1
+}
+
+impl<'this> OwningIovec<'this> {
+    /// Creates an empty instance that will allocate from its fresh
+    /// private arena.
+    #[must_use]
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Creates an empty instance that will allocate from `arena`
+    #[must_use]
+    pub fn new_from_arena(arena: ByteArena) -> Self {
+        OwningIovec::new_from_slices(Vec::new(), Some(arena))
+    }
+
+    /// Creates a new instance with these initial [`IoSlice`]s
+    /// and the arena, if provided; uses a fresh arena if [`None`].
+    #[must_use]
+    pub fn new_from_slices(mut slices: Vec<IoSlice<'this>>, arena: Option<ByteArena>) -> Self {
+        slices.retain(|slice| slice.len() > 0);
+        OwningIovec {
+            slices: GlobalDeque::new(slices),
+            arena: arena.unwrap_or_default(),
+            ..Default::default()
+        }
+    }
+
+    /// Returns a reference to the underlying arena
+    #[must_use]
+    #[inline(always)]
+    pub fn arena(&mut self) -> &mut ByteArena {
+        &mut self.arena
+    }
+
+    /// Returns a [`ConsumingIovec`] for this [`OwningIovec`].
+    #[must_use]
+    #[inline(always)]
+    pub fn consumer(&mut self) -> ConsumingIovec<'_> {
+        self.into()
+    }
+
+    /// Attempts to return a [`StableIovec`] for this [`OwningIovec`].
+    /// Returns a [`ConsumingIovec`] as the `Err` if this [`OwningIovec`]
+    /// has backreferences in flight.
+    #[inline(always)]
+    pub fn stable_consumer(&mut self) -> Result<StableIovec<'_>, ConsumingIovec<'_>> {
+        self.consumer().try_into()
+    }
+
+    /// Replaces `self` with a default-constructued [`OwningIovec`] and
+    /// returns the initial `self`.
+    #[must_use]
+    pub fn take(&mut self) -> Self {
+        let mut ret = Default::default();
+        std::mem::swap(self, &mut ret);
+        ret
+    }
+
+    /// Clears the internal state (buffered slices and pending backreferences),
+    /// but keeps the backing [`ByteArena`] untouched.
+    pub fn clear(&mut self) {
+        self.slices.clear();
+        self.backrefs.clear();
+    }
+
+    /// Pushes `slice` to the internal vector of [`IoSlice`]s.
+    ///
+    /// Small slices are copied, large ones borrowed, and
+    /// medium-sized one may be copied when it makes sense.
+    ///
+    /// This method takes constant amortised time wrt `slice.len()`.
+    pub fn push(&mut self, slice: &'this [u8]) {
+        let small = slice.len() <= SMALL_COPY;
+        let appendable = (slice.len() <= MAX_OPPORTUNISTIC_COPY)
+            & (self.arena.remaining() >= slice.len())
+            & (self
+                .slices
+                .last_slice()
+                .map(|slice| self.arena.is_last(slice))
+                == Some(true));
+
+        if small | appendable {
+            self.push_copy(slice);
+        } else {
+            self.push_borrowed(slice);
+        }
+    }
+
+    /// Pushes `slice` to the internal vector of [`IoSlice`],
+    /// without copying the contents.
+    ///
+    /// This method takes constant amortised time wrt `slice.len()`.
+    pub fn push_borrowed(&mut self, slice: &'this [u8]) {
+        if slice.is_empty() {
+            return;
+        }
+
+        self.slices.push_borrowed(IoSlice::new(slice));
+        self.optimize();
+    }
+
+    /// Pushes a copy of `src` to the internal vector of [`IoSlice`].
+    ///
+    /// This method takes lines time wrt `slice.len()`.
+    pub fn push_copy(&mut self, src: &[u8]) {
+        if src.is_empty() {
+            return;
+        }
+
+        let last_anchor = self.slices.last_anchor();
+        let (slice, anchor) = unsafe { self.arena.copy(src, last_anchor) };
+        self.slices.push((slice, anchor));
+        self.optimize();
+    }
+
+    /// Extends the internal vector of [`IoSlice`]s with each item in `iovs`.
+    pub fn extend(&mut self, iovs: impl IntoIterator<Item = IoSlice<'this>>) {
+        for iov in iovs {
+            if iov.is_empty() {
+                continue;
+            }
+
+            self.slices.push_borrowed(iov);
+            self.optimize();
+        }
+    }
+
+    /// Schedules `anchor` to be dropped once all the currently
+    /// buffered slices are consumed.
+    #[inline(always)]
+    pub fn push_anchor(&mut self, anchor: Anchor) {
+        self.slices.push_anchor(anchor);
+    }
+
+    /// Registers a backreference at the current write location, with
+    /// the `pattern`'s size.
+    pub fn register_patch(&mut self, pattern: &[u8]) -> Backref {
+        if pattern.is_empty() {
+            let ret = Backref(None);
+            assert!(ret.is_empty());
+            return ret;
+        }
+
+        // XXX: this assumes the optimisation process only tries to merge
+        // the most recently pushed slice with the immediately preceding one.
+        self.push_copy(pattern);
+        assert!(!self.is_empty());
+
+        let pattern_size = pattern.len();
+        let logical_index = self.slices.logical_size() - (pattern_size as u64);
+        let info = BackrefInfo {
+            slice_index: self.slices.last_logical_slice_index(),
+            begin: ioslice_len(self.slices.last_slice().unwrap()) - pattern_size,
+            len: NonZeroUsize::try_from(pattern_size).unwrap(), // We checked for emptiness above
+        };
+        self.backrefs
+            .push_back_or_panic((logical_index, Some(info)));
+        let ret = Backref(Some((logical_index, info)));
+        assert!(!ret.is_empty());
+        ret
+    }
+
+    /// Backpopulates a backreference created for this [`OwningIovec`].
+    ///
+    /// Panics if `src` does not match the backreference's size, or if
+    /// the backref does not come from the [`OwningIovec`].
+    pub fn backfill_or_panic(&mut self, backref: Backref, src: &[u8]) {
+        let (logical_index, info) = match backref.0 {
+            None => {
+                // Can only have empty backref.
+                assert_eq!(src, &[]);
+                return;
+            }
+            Some(backref) => backref,
+        };
+
+        assert_eq!(usize::from(info.len), src.len());
+        let backref_found_in_instance = self
+            .backrefs
+            .remove(&logical_index)
+            .expect("backref not found");
+        assert_eq!(backref_found_in_instance, (logical_index, Some(info)));
+
+        let target = self
+            .slices
+            .get_logical_slice(info.slice_index)
+            .expect("must still be present");
+        let (base, len) = ioslice::ioslice_components(target);
+
+        assert!(info.begin + src.len() <= len);
+        let dst = unsafe { base.add(info.begin) };
+        unsafe { std::ptr::copy(src.as_ptr(), dst, src.len()) };
+    }
+
+    /// Attempts to join together the last two slices in `self.iovs()`
+    /// if it's definitely safe to do so.  This method onl works on
+    /// the last two slices because we call it whenever a slice is
+    /// pushed to `self.iovs`.
+    #[inline(always)]
+    fn optimize(&mut self) {
+        self.slices
+            .maybe_collapse_last_pair(|left, right| unsafe { self.arena.try_join(left, right) });
+    }
+}
+
+// pure read methods
+impl OwningIovec<'_> {
+    /// Determines whether this [`OwningIovec`] currently has
+    /// backreferences in flight.
+    #[must_use]
+    #[inline(always)]
+    pub fn has_pending_backrefs(&self) -> bool {
+        !self.backrefs.is_empty()
+    }
+
+    /// Returns a prefix of the owned slices such that none of the
+    /// returned slices contain a backpatch.
+    #[must_use]
+    #[inline(always)]
+    pub fn stable_prefix(&self) -> &[IoSlice<'_>] {
+        // Unwrap because, if we have an element, its value is `Some`.
+        let stop_slice_index = self
+            .backrefs
+            .first()
+            .map(|backref| backref.1.unwrap().slice_index);
+        self.slices.get_logical_prefix(stop_slice_index)
+    }
+
+    /// Peeks at the next stable IoSlice
+    #[must_use]
+    #[inline(always)]
+    pub fn front(&self) -> Option<IoSlice<'_>> {
+        self.stable_prefix().first().copied()
+    }
+
+    /// The [`OwningIovec::iovs`] method is the only way to borrow
+    /// [`IoSlice`]s from an [`OwningIovec`]. The lifetime constraints
+    /// ensure that the return value outlives neither `this` nor `self`.
+    ///
+    /// Returns the stable prefix if some backrefs are still in flight.
+    #[inline(always)]
+    pub fn iovs(&self) -> Result<&[IoSlice<'_>], &[IoSlice<'_>]> {
+        let ret = self.stable_prefix();
+        if self.has_pending_backrefs() {
+            Err(ret)
+        } else {
+            Ok(ret)
+        }
+    }
+
+    /// Returns the number of slices in the [`OwningIovec`].
+    ///
+    /// This includes slices that are still waiting for a backpatch.
+    #[must_use]
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.slices.num_slices()
+    }
+
+    /// Determines whether the [`OwningIovec`] contains 0 slices.
+    #[must_use]
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the total number of bytes in `self.iovs`.
+    ///
+    /// This includes slices that are still waiting for a backpatch.
+    #[must_use]
+    #[inline(always)]
+    pub fn total_size(&self) -> usize {
+        self.slices.total_size()
+    }
+
+    /// Returns the contents of this iovec as a single [`Vec<u8>`].
+    ///
+    /// Returns the stable contents as an error if there is any backreference in flight.
+    #[inline(always)]
+    pub fn flatten(&self) -> Result<Vec<u8>, Vec<u8>> {
+        self.flatten_into(Vec::with_capacity(self.total_size()))
+    }
+
+    /// Appends the contents of this iovec so `dst`.
+    ///
+    /// Returns the stable contents as an error if there is any backreference in flight.
+    #[inline(always)]
+    pub fn flatten_into(&self, dst: Vec<u8>) -> Result<Vec<u8>, Vec<u8>> {
+        let ret = self.flatten_into_impl(dst);
+
+        if self.has_pending_backrefs() {
+            Err(ret)
+        } else {
+            Ok(ret)
+        }
+    }
+
+    #[must_use]
+    #[inline(never)]
+    fn flatten_into_impl(&self, mut dst: Vec<u8>) -> Vec<u8> {
+        dst.reserve(self.total_size());
+        for iov in self.stable_prefix() {
+            dst.extend_from_slice(iov);
+        }
+
+        dst
+    }
+}
+
+impl<'a> ConsumingIovec<'a> {
+    /// Returns a reference to the underlying arena.
+    #[must_use]
+    #[inline(always)]
+    pub fn arena(&mut self) -> &mut ByteArena {
+        &mut self.iovec().arena
+    }
+
+    /// Returns the underlying arena and replaces it with a new
+    /// default-constructed arena.
+    #[must_use]
+    pub fn take_arena(&mut self) -> ByteArena {
+        self.swap_arena(Default::default())
+    }
+
+    /// Replaces the underlying arena with the argument and returns
+    /// the old underlying arena.
+    pub fn swap_arena(&mut self, mut arena: ByteArena) -> ByteArena {
+        std::mem::swap(&mut arena, self.arena());
+        arena
+    }
+
+    /// Pops the first [`IoSlice`].  Panics if the [`OwningIovec`] has no stable prefix.
+    #[inline(always)]
+    pub fn pop_front(&mut self) {
+        let consumed = self.consume(1);
+        assert_eq!(consumed, 1);
+    }
+
+    /// Pops up to the next `count` [`IoSlice`]s returned by [`OwningIovec::stable_prefix`].
+    ///
+    /// Returns the number of slices consumed.
+    #[inline(always)]
+    pub fn consume(&mut self, count: usize) -> usize {
+        let num_slices = self.stable_prefix().len();
+        self.iovec().slices.consume(count.min(num_slices))
+    }
+
+    /// Pops up to the next `count` bytes in the slices returned by [`OwningIovec::stable_prefix`].
+    ///
+    /// Returns the number of bytes consumed.
+    pub fn advance_slices(&mut self, count: usize) -> usize {
+        let mut stable_count = 0;
+        for slice in self.stable_prefix() {
+            let size = slice.len();
+            if size >= count - stable_count {
+                stable_count = count;
+                break;
+            }
+
+            stable_count += size;
+        }
+
+        self.iovec().slices.consume_by_bytes(stable_count)
+    }
+}
+
+impl StableIovec<'_> {
+    /// Returns the slices of bytes buffered in the underlying [`OwningIovec`].
+    #[must_use]
+    #[inline(always)]
+    pub fn iovs(&self) -> &[IoSlice<'_>] {
+        self.stable_prefix()
+    }
+
+    /// Returns a copy of the contents of the underlying [`OwningIovec`].
+    #[must_use]
+    #[inline(always)]
+    pub fn flatten(&self) -> Vec<u8> {
+        self.flatten_into(Vec::with_capacity(self.total_size()))
+    }
+
+    /// Appends a copy of the contents of the underlying [`OwningIovec`]
+    /// after `dst`.
+    #[must_use]
+    #[inline(always)]
+    pub fn flatten_into(&self, dst: Vec<u8>) -> Vec<u8> {
+        self.flatten_into_impl(dst)
+    }
+}
+
+impl<'life> IntoIterator for &'life OwningIovec<'_> {
+    type Item = &'life IoSlice<'life>;
+    type IntoIter = std::slice::Iter<'life, IoSlice<'life>>;
+
+    fn into_iter(self) -> std::slice::Iter<'life, IoSlice<'life>> {
+        self.stable_prefix().iter()
+    }
+}
+
+impl<'life> FromIterator<IoSlice<'life>> for OwningIovec<'life> {
+    fn from_iter<T: IntoIterator<Item = IoSlice<'life>>>(iter: T) -> OwningIovec<'life> {
+        let slices: Vec<IoSlice<'life>> = iter.into_iter().collect();
+
+        OwningIovec::new_from_slices(slices, None)
+    }
+}
+
+impl<'life> FromIterator<&'life IoSlice<'life>> for OwningIovec<'life> {
+    #[inline(always)]
+    fn from_iter<T: IntoIterator<Item = &'life IoSlice<'life>>>(iter: T) -> OwningIovec<'life> {
+        OwningIovec::from_iter(iter.into_iter().copied())
+    }
+}
+
+// Exercise simple iovec optimisation
+#[test]
+fn test_happy_optimize_miri() {
+    use std::io::Write;
+
+    let mut iovs: OwningIovec = vec![&b""[..]].into_iter().map(IoSlice::new).collect();
+
+    // We don't do anything for zero-sized slices
+    iovs.push_borrowed(b"");
+    iovs.push_copy(b"");
+    iovs.push(b"");
+    assert!(iovs.is_empty());
+
+    // Push small slices
+    iovs.push_borrowed(b"000");
+
+    // Copy a bunch of slices that can be concatenated in place.
+    iovs.arena().ensure_capacity(10);
+    iovs.push_copy(b"123");
+    iovs.arena().ensure_capacity(7);
+    iovs.push_copy(b"456");
+    iovs.push(b"7");
+    iovs.push_borrowed(b"aaa");
+    iovs.push_anchor(Default::default());
+
+    // We expect 3 ioslices:
+    // 1 for the initial `push_borrowed`,
+    // 1 for the "123", "456", then "7" (optimised as copy)
+    // 1 for the final `push_borrowed`
+    assert_eq!(iovs.len(), 3);
+    assert_eq!(iovs.total_size(), 13);
+
+    let mut dst = Vec::new();
+    assert_eq!(
+        dst.write_vectored(iovs.iovs().unwrap())
+            .expect("must_succeed"),
+        13
+    );
+
+    assert_eq!(dst, b"0001234567aaa");
+
+    // now consume 4 bytes.
+    assert_eq!(iovs.consumer().advance_slices(4), 4);
+    assert_eq!(iovs.len(), 2);
+    assert_eq!(iovs.total_size(), 9);
+
+    assert_eq!(iovs.flatten().unwrap(), b"234567aaa");
+
+    assert_eq!(
+        iovs.stable_consumer()
+            .expect("no backref")
+            .advance_slices(100),
+        9
+    );
+    assert!(iovs.is_empty());
+    assert_eq!(iovs.len(), 0);
+    assert_eq!(iovs.total_size(), 0);
+    assert_eq!(iovs.stable_consumer().unwrap().flatten(), b"");
+
+    assert_eq!(iovs.consumer().advance_slices(100), 0);
+    assert_eq!(iovs.flatten().unwrap(), b"");
+}
+
+// Make sure we don't optimize when there's a gap.
+#[test]
+fn test_no_optimize_gap_miri() {
+    let slices = [IoSlice::new(&b""[..])];
+    let mut iovs: OwningIovec = slices.iter().collect();
+
+    iovs.push_borrowed(b"000");
+    iovs.push_copy(b"123");
+    // Create a gap in the copied allocations.
+    let _ = unsafe { iovs.arena.copy(b"xxx", None) };
+    iovs.push_copy(b"456");
+    iovs.push_borrowed(b"aaa");
+
+    // Force a realloc, make sure this doesn't do weird stuff.
+    let mut arena = iovs.consumer().take_arena();
+    arena.ensure_capacity(10000);
+    iovs.consumer().swap_arena(arena);
+
+    assert_eq!(iovs.len(), 4);
+    assert_eq!(iovs.total_size(), 12);
+
+    assert_eq!(iovs.flatten_into(vec![0x42]).unwrap(), b"\x42000123456aaa");
+}
+
+// Make sure we *don't* optimize when the arena's cache
+// is reused for another `OwningIovec`.
+#[test]
+fn test_no_optimize_flush_miri() {
+    let mut iovs = OwningIovec::new();
+
+    iovs.push_borrowed(b"000");
+    iovs.push_copy(b"123");
+
+    // Mess with the cached allocation
+    iovs.arena().flush_cache();
+    iovs.clone().push_copy(b"123");
+
+    // Shouldn't merge with the previous.
+    iovs.push_copy(b"456");
+    iovs.push_borrowed(b"aaa");
+
+    assert_eq!(iovs.len(), 4);
+    assert_eq!(iovs.total_size(), 12);
+
+    assert_eq!(iovs.flatten().unwrap(), b"000123456aaa");
+}
+
+// Exercise the `extend` method.
+#[test]
+fn test_extend_miri() {
+    use std::io::Write;
+
+    let mut iovs2 = OwningIovec::new();
+    let mut iovs = OwningIovec::new();
+
+    iovs.push_borrowed(b"000");
+    iovs2.push_copy(b"123");
+    iovs2.push_copy(b"456");
+    iovs.extend(iovs2.into_iter().copied());
+
+    // We don't expect empty slices, but we should still drop them on
+    // the floot.
+    iovs.extend([IoSlice::new(&[0u8][..0]), IoSlice::new(&[0u8])]);
+    iovs.push_borrowed(b"aaa");
+
+    assert_eq!(iovs.len(), 4);
+    assert_eq!(iovs.total_size(), 13);
+
+    let mut dst = Vec::new();
+    assert_eq!(
+        dst.write_vectored(iovs.stable_consumer().unwrap().iovs())
+            .expect("must_succeed"),
+        13
+    );
+
+    assert_eq!(dst, b"000123456\x00aaa");
+}
+
+// Make sure we can reuse arenas for multiple OwningIovec
+#[test]
+fn test_inherit_miri() {
+    use std::io::Write;
+
+    let mut iovs2 = OwningIovec::new();
+    let mut iovs = OwningIovec::new();
+
+    iovs.push(b"000");
+    iovs2.push_copy(b"123");
+    iovs2.push_copy(b"456");
+    iovs.extend(iovs2.into_iter().copied());
+    iovs.push(b"aaa");
+
+    assert!(iovs.len() <= 3);
+    assert_eq!(iovs.total_size(), 12);
+
+    let mut dst = Vec::new();
+    assert_eq!(
+        dst.write_vectored(iovs.iovs().unwrap())
+            .expect("must_succeed"),
+        12
+    );
+
+    assert_eq!(dst, b"000123456aaa");
+}
+
+// Make sure we can steal another iov's arena
+#[test]
+fn test_inherit2_miri() {
+    use std::io::Write;
+
+    let mut iovs2;
+    let mut iovs = OwningIovec::new();
+
+    iovs.push(b"000");
+    iovs2 = OwningIovec::new_from_arena(iovs.consumer().take_arena());
+    iovs2.push_copy(b"123");
+    iovs2.push_copy(b"456");
+    iovs.extend(iovs2.iovs().unwrap().iter().copied());
+    iovs.push(b"aaa");
+
+    assert!(iovs.len() <= 3);
+    assert_eq!(iovs.total_size(), 12);
+
+    let mut dst = Vec::new();
+    assert_eq!(
+        dst.write_vectored(iovs.iovs().unwrap())
+            .expect("must_succeed"),
+        12
+    );
+
+    assert_eq!(dst, b"000123456aaa");
+}
+
+// Make sure we merge a 128-byte `push` with the previous owned slice.
+#[test]
+fn test_medium_write_merge_miri() {
+    use std::io::Write;
+
+    let mut iovs = OwningIovec::new();
+
+    iovs.push_copy(&[1u8; 3]);
+    iovs.push(&[1u8; 128]);
+
+    assert_eq!(iovs.len(), 1);
+    assert_eq!(iovs.total_size(), 131);
+
+    let mut dst = Vec::new();
+    assert_eq!(
+        dst.write_vectored(iovs.iovs().unwrap())
+            .expect("must_succeed"),
+        131
+    );
+
+    assert_eq!(dst, [1u8; 131]);
+}
+
+// Make sure we gracefully handle the case where the final copy doesn't fit in the
+// the previous copy's arena, so can't be merged.
+#[test]
+fn test_medium_write_disjoint_miri() {
+    use std::io::Write;
+
+    let mut iovs = OwningIovec::new_from_slices(vec![IoSlice::new(&[1u8; 3])], None);
+    iovs.push_copy(&[1u8; 128]);
+    iovs.arena().flush_cache();
+    iovs.push_copy(&[1u8; 4096]);
+
+    assert_eq!(iovs.len(), 3);
+    assert_eq!(iovs.total_size(), 3 + 128 + 4096);
+
+    let mut dst = Vec::new();
+    assert_eq!(
+        dst.write_vectored(iovs.iovs().unwrap())
+            .expect("must_succeed"),
+        3 + 128 + 4096
+    );
+
+    assert_eq!(dst, [1u8; 3 + 128 + 4096]);
+}
+
+// `push` should borrow for larger slices.
+#[test]
+fn test_large_write_miri() {
+    use std::io::Write;
+
+    let mut iovs = OwningIovec::new();
+
+    iovs.push_copy(&[1u8; 3]);
+    iovs.push(&[1u8; 1024]);
+    iovs.push_copy(&[1u8; 4093]);
+    iovs.arena().flush_cache();
+
+    assert_eq!(iovs.len(), 3);
+    assert_eq!(iovs.total_size(), 3 + 1024 + 4093);
+
+    let mut dst = Vec::new();
+    assert_eq!(
+        dst.write_vectored(iovs.iovs().unwrap())
+            .expect("must_succeed"),
+        3 + 1024 + 4093
+    );
+
+    assert_eq!(dst, [1u8; 3 + 1024 + 4093]);
+}
+
+// Backref happy path
+#[test]
+fn test_backref_miri() {
+    let mut iovs = OwningIovec::new();
+
+    // Special safe case: empty patch.
+    let empty = iovs.register_patch(&[]);
+
+    assert!(iovs.iovs().is_ok());
+
+    let backref = iovs.register_patch(&[0u8]);
+    iovs.push(b"123");
+    let other_backref = iovs.register_patch(&[0u8; 2]);
+    iovs.push(b"56789");
+
+    assert!(iovs.front().is_none());
+    assert!(iovs.stable_consumer().is_err());
+    assert!(iovs.iovs().is_err());
+
+    iovs.backfill_or_panic(backref, b"a");
+    assert!(iovs.iovs().is_err());
+    assert!(iovs.flatten().is_err());
+    assert!(iovs.front().is_none());
+
+    iovs.backfill_or_panic(other_backref, b"bb");
+
+    assert!(iovs.iovs().is_ok());
+    assert!(iovs.front().is_some());
+    assert_eq!(&*iovs.front().unwrap(), b"a123bb56789");
+
+    assert_eq!(iovs.flatten().unwrap(), b"a123bb56789");
+
+    iovs.backfill_or_panic(empty, b"");
+    assert_eq!(iovs.flatten().unwrap(), b"a123bb56789");
+
+    iovs.consumer().pop_front();
+
+    assert!(iovs.is_empty());
+}
+
+// Make sure we still do the right thing when slices around the backref are borrowed.
+#[test]
+fn test_backref_borrowed_miri() {
+    let mut iovs = OwningIovec::new();
+
+    let backref = iovs.register_patch(&[0u8]);
+    iovs.push_borrowed(b"123");
+    let other_backref = iovs.register_patch(&[0u8; 2]);
+    iovs.push(b"56789");
+
+    assert!(iovs.iovs().is_err());
+
+    iovs.backfill_or_panic(backref, b"a");
+    assert!(iovs.iovs().is_err());
+    // We can read the first slice now.
+    assert_eq!(&*iovs.front().unwrap(), b"a");
+
+    iovs.backfill_or_panic(other_backref, b"bb");
+
+    assert!(iovs.iovs().is_ok());
+
+    assert_eq!(iovs.flatten().unwrap(), b"a123bb56789");
+}
+
+// Make sure we still do the right thing when slices around the backref are borrowed.
+#[test]
+fn test_backref_borrowed2_miri() {
+    let mut iovs = OwningIovec::new();
+
+    let backref = iovs.register_patch(&[0u8]);
+    iovs.push(b"123");
+    let other_backref = iovs.register_patch(&[0u8; 2]);
+    iovs.push_borrowed(b"56789");
+
+    assert!(iovs.iovs().is_err());
+
+    iovs.backfill_or_panic(backref, b"a");
+    assert!(iovs.iovs().is_err());
+    assert!(iovs.front().is_none()); // still waiting for the second backref
+
+    iovs.backfill_or_panic(other_backref, b"bb");
+    assert_eq!(&*iovs.front().unwrap(), b"a123bb");
+
+    assert!(iovs.iovs().is_ok());
+
+    assert_eq!(iovs.flatten().unwrap(), b"a123bb56789");
+}
+
+// Make sure we still do the right thing when all slices around the backref are borrowed.
+#[test]
+fn test_backref_all_borrowed_miri() {
+    let mut iovs = OwningIovec::new();
+
+    let backref = iovs.register_patch(&[0u8]);
+    iovs.push_borrowed(b"123");
+    let other_backref = iovs.register_patch(&[0u8; 2]);
+    iovs.push_borrowed(b"56789");
+
+    assert!(iovs.iovs().is_err());
+
+    iovs.backfill_or_panic(backref, b"a");
+    assert!(iovs.iovs().is_err());
+    assert_eq!(&*iovs.front().unwrap(), b"a");
+
+    iovs.backfill_or_panic(other_backref, b"bb");
+
+    assert!(iovs.iovs().is_ok());
+
+    assert_eq!(iovs.flatten().unwrap(), b"a123bb56789");
+
+    assert_eq!(&*iovs.front().unwrap(), b"a");
+    iovs.consumer().pop_front();
+    assert_eq!(&*iovs.front().unwrap(), b"123");
+    iovs.consumer().pop_front();
+
+    assert_eq!(iovs.len(), 2);
+    assert_eq!(iovs.total_size(), 2 + 5);
+
+    assert_eq!(iovs.flatten().unwrap(), b"bb56789");
+}

--- a/owning_iovec/src/ioslice.rs
+++ b/owning_iovec/src/ioslice.rs
@@ -1,0 +1,109 @@
+//! Use the backing foreign type to manipulate [`IoSlice`]s without converting
+//! back to regular slices: the conversion to slices introduces stacked borrow
+//! constraints.
+#[cfg(unix)]
+mod unix {
+    use std::io::IoSlice;
+
+    const _: () =
+        assert!(std::mem::size_of::<libc::iovec>() == std::mem::size_of::<IoSlice<'static>>());
+
+    /// Creates an `IoSlice<'static>` from a raw pointer and length.
+    ///
+    /// # Safety
+    ///
+    /// The `'static` lifetime is a lie; the caller must ensure that the
+    /// memory region pointed to by `base` with length `len` is valid for the
+    /// lifetime of the returned `IoSlice`.
+    #[must_use]
+    #[inline]
+    pub fn make_ioslice(base: *mut u8, len: usize) -> IoSlice<'static> {
+        let ret = libc::iovec {
+            iov_base: base as *mut _,
+            iov_len: len,
+        };
+
+        unsafe { std::mem::transmute(ret) }
+    }
+
+    /// Returns the base pointer and length of the given `IoSlice<'_>`.
+    #[must_use]
+    #[inline]
+    pub fn ioslice_components(slice: IoSlice<'_>) -> (*mut u8, usize) {
+        let ret: libc::iovec = unsafe { std::mem::transmute(slice) };
+
+        (ret.iov_base as *mut u8, ret.iov_len)
+    }
+}
+
+#[cfg(unix)]
+pub use unix::{ioslice_components, make_ioslice};
+
+#[allow(unused)]
+mod windows {
+    use std::io::IoSlice;
+
+    // https://learn.microsoft.com/en-us/windows/win32/api/ws2def/ns-ws2def-wsabuf
+    //
+    // typedef struct _WSABUF {
+    //   ULONG len;
+    //   CHAR  *buf;
+    // } WSABUF, *LPWSABUF;
+    struct WSABuf {
+        len: u32, // Windows is LLP64, so ULONG is 32 bits.
+        buf: *mut u8,
+    }
+
+    const _: () = assert!(std::mem::size_of::<WSABuf>() == std::mem::size_of::<IoSlice<'static>>());
+
+    /// Creates an `IoSlice<'static>` from a raw pointer and length.
+    ///
+    /// # Safety
+    ///
+    /// The `'static` lifetime is a lie; the caller must ensure that the
+    /// memory region pointed to by `base` with length `len` is valid for the
+    /// lifetime of the returned `IoSlice`.
+    #[must_use]
+    #[inline]
+    pub fn make_ioslice(base: *mut u8, len: usize) -> IoSlice<'static> {
+        let ret = WSABuf {
+            len: len
+                .try_into()
+                .expect("ioslice must not exceed 4 GB on windows"),
+            buf: base,
+        };
+
+        unsafe { std::mem::transmute(ret) }
+    }
+
+    /// Returns the base pointer and length of the given `IoSlice<'_>`.
+    #[must_use]
+    #[inline]
+    pub fn ioslice_components(slice: IoSlice<'_>) -> (*mut u8, usize) {
+        let ret: WSABuf = unsafe { std::mem::transmute(slice) };
+
+        (ret.buf, ret.len as usize)
+    }
+}
+
+#[cfg(windows)]
+pub use windows::{ioslice_components, make_ioslice};
+
+#[test]
+fn test_roundtrip_miri() {
+    use std::io::IoSlice;
+
+    let data = vec![1, 2, 3];
+    let slice = IoSlice::new(&data);
+
+    let (base, len) = ioslice_components(slice);
+    assert_eq!(base as *const u8, data.as_ptr_range().start);
+    assert_eq!(len, data.len());
+
+    let new_slice = make_ioslice(base, len);
+    assert_eq!(&*slice, &*new_slice);
+    assert_eq!(slice.as_ptr(), new_slice.as_ptr());
+    assert_eq!(slice.len(), new_slice.len());
+
+    assert_eq!(ioslice_components(slice), ioslice_components(new_slice))
+}

--- a/owning_iovec/src/lib.rs
+++ b/owning_iovec/src/lib.rs
@@ -1,0 +1,86 @@
+//! The `owning_iovec` crate exposes an [`OwningIovec`] object that
+//! supports on-the-fly production and consumption of bytes (i.e.,
+//! like an in-memory pipe), along with supporting machinery.  Unlike
+//! classical pipes or buffers, the [`OwningIovec`] works in terms
+//! of slices, some of which may be borrowed without a byte copy.
+//!
+//! An [`OwningIovec`] may also own slices; the allocations that back
+//! owned slices are tracked internally and released as the slices are
+//! consumed.
+//!
+//! For producers, the [`OwningIovec`] also supports backreferences:
+//! rather than each producer having to implement its own buffering,
+//! producers may now pre-allocate mutable slices, and backfill them
+//! after the fact.  On-the-fly consumption will be blocked from
+//! consuming slices while the backpatch is still pending.
+//!
+//! Consumers get an *asymptotic* on-the-fly consumption: there is no
+//! guarantee that consumers can read a steady flow of bytes, even
+//! when their producer generates bytes.  The guarantee is rather that
+//! the amount of bytes buffered in an `[OwningIovec`] is bounded,
+//! as a constant multiple of the largest slices lent to the [`OwningIovec`].
+//!
+//! Producers work with [`OwningIovec`], [`Backref`], and
+//! [`AnchoredSlice`] (produced by [`ByteArena`]).
+//!
+//! Consumers handle [`ConsumingIovec`] or, if they must know that the
+//! producer does not have any backreference in flight, [`StableIovec`].
+mod byte_arena;
+mod global_deque;
+mod implementation;
+mod ioslice;
+
+pub use byte_arena::AnchoredSlice;
+pub use byte_arena::ByteArena;
+pub use implementation::Backref;
+pub use implementation::ConsumingIovec;
+pub use implementation::OwningIovec;
+pub use implementation::StableIovec;
+
+impl std::io::Read for ConsumingIovec<'_> {
+    fn read(&mut self, mut dst: &mut [u8]) -> std::io::Result<usize> {
+        let mut written = 0;
+        while !dst.is_empty() {
+            let Some(slice) = self.front() else {
+                break;
+            };
+
+            let to_write = slice.len().min(dst.len());
+            dst[..to_write].copy_from_slice(&slice[..to_write]);
+            self.advance_slices(to_write);
+            written += to_write;
+            dst = &mut dst[to_write..];
+        }
+
+        Ok(written)
+    }
+}
+
+#[test]
+fn test_read() {
+    use std::io::Read;
+
+    let mut iovec = OwningIovec::new();
+    iovec.push_copy(b"123");
+    iovec.push(b"456");
+
+    let mut dst = Vec::new();
+    iovec
+        .consumer()
+        .read_to_end(&mut dst)
+        .expect("should succeed");
+    assert_eq!(dst, b"123456");
+}
+
+#[test]
+fn test_read_short() {
+    use std::io::Read;
+
+    let mut iovec = OwningIovec::new();
+    iovec.push_copy(b"123");
+    iovec.push(b"456");
+
+    let mut dst = [0u8; 4];
+    assert_eq!(iovec.consumer().read(&mut dst).expect("should succeed"), 4);
+    assert_eq!(&dst, b"1234");
+}


### PR DESCRIPTION
OwningIovec is a decent chunk of memory management functionality.  The OwningIovec data structure exists to centralise buffering in one places.  It can be used in a zero-copy fashion, for input slices that outlive the `OwningIovec`'s lifetime parameter (which can always be 'static).

When zero-copy isn't possible or wanted, the `OwningIovec` can also allocate from an arena and maintain ownership of the slices.  We also detect the common case of pushing new contiguous allocations from the same arena to the `OwningIovec` and accelerate that path: we avoid `Arc` increments and merge the slices to we only have to track one.

For producers, the OwningIovec can also manage backpatch locations: writers may insert *fixed size* placeholders, and populate them after the fact (which can be useful for things like checksums or size headers).  It's hard to describe that interface to the borrow checker, so *programming errors* can turn into panics, but it's probably better than trying to handle backpatching "by hand."

For readers, the OwningIovec can return the "stable" prefix of buffered slices: those are the slices that are fully populated, without any unpopulated placeholder in or before them.  Readers may consume incrementally from the `OwningIovec` (e.g., to write to a file while its contents are still being produced); the `OwningIovec`'s read pointer will move forward, without affecting the writer, and owned storage be freed, one arena chunk at a time.

There is currently no way to zero-copy move slices from one OwningIovec to another, but it's probably doable, by passing around `(Buf<[IoSlice]>, SmallVec<[Anchor; ...]>)` pairs.

The lifetimes here are tricky. Use MIRI and a lot of unit tests.

There's nothing interesting in ioslice.rs, just some transmute magic to access the innards of `IoSlice` without reifying slices (which makes MIRI super mad).

Start reading byte_arena/anchor, then byte_arena/alloc_cache and and byte_arena/mod: the anchoring system appears everywhere.

After that, global_deque manages `IoSlice`s and associated `Anchor`s, and `implementation` brings it all together.