### PR TITLE
Add trivial_zip_wrapper crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "hcobs",
   "owning_iovec",
   "sliding_deque",
+  "trivial_zip_wrapper",
   "vouched_time",
 ]
 

--- a/trivial_zip_wrapper/Cargo.toml
+++ b/trivial_zip_wrapper/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "trivial_zip_wrapper"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+owning_iovec = { path = "../owning_iovec" }
+
+[dev-dependencies]
+zip = "2"
+
+[lints]
+workspace = true

--- a/trivial_zip_wrapper/src/headers.rs
+++ b/trivial_zip_wrapper/src/headers.rs
@@ -1,0 +1,338 @@
+//! The `header` struct contains models for the ZIP-format's headers.
+//!
+//! See https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
+//! APPNOTE.TXT - .ZIP File Format Specification
+//! Version 6.3.10
+
+/// Constructs a Zip64 local header for "STORED" file with name
+/// `filename` and total `size` bytes.
+///
+/// If `filename` exceeds u16::MAX bytes, it is truncated silently.
+pub fn construct_local_file_header(filename: &str, size: u64) -> Vec<u8> {
+    // XXX: silently clamp the filename, we can't have paths that long
+    // in real life.
+    let filename_len: u16 = filename.as_bytes().len().min(u16::MAX as usize) as u16;
+    let filename = &filename.as_bytes()[..filename_len as usize];
+
+    let expected_size = 30 + filename.len() + 20;
+    let mut dst = Vec::with_capacity(expected_size);
+
+    // 30 bytes for the local file header
+
+    // 4.3.7  Local file header:
+    //
+    //    local file header signature     4 bytes  (0x04034b50)
+    //    version needed to extract       2 bytes
+    //    general purpose bit flag        2 bytes
+    //    compression method              2 bytes
+    //    last mod file time              2 bytes
+    //    last mod file date              2 bytes
+    //    crc-32                          4 bytes
+    //    compressed size                 4 bytes
+    //    uncompressed size               4 bytes
+    //    file name length                2 bytes
+    //    extra field length              2 bytes
+    //
+    //    file name (variable size)
+    //    extra field (variable size)
+
+    // Signature
+    dst.extend_from_slice(b"PK\x03\x04");
+    // Version 4.5 (for Zip64)
+    dst.extend_from_slice(&45u16.to_le_bytes());
+    // Flags XXX: should we set 13?
+    dst.extend_from_slice(&0u16.to_le_bytes());
+    // Compression method (STORE)
+    dst.extend_from_slice(&0u16.to_le_bytes());
+    // Time
+    dst.extend_from_slice(&0u16.to_le_bytes());
+    // Date
+    dst.extend_from_slice(&0u16.to_le_bytes());
+    // CRC
+    dst.extend_from_slice(&0u32.to_le_bytes());
+    // Uncompressed size (escape to zip64)
+    dst.extend_from_slice(&u32::MAX.to_le_bytes());
+    // Compressed size (escape to zip64)
+    dst.extend_from_slice(&u32::MAX.to_le_bytes());
+    // Filename length
+    dst.extend_from_slice(&filename_len.to_le_bytes());
+    // Extension size
+    dst.extend_from_slice(&20u16.to_le_bytes());
+
+    // file name
+    dst.extend_from_slice(filename);
+
+    // 20 bytes for the Zip64 extra field
+
+    // 4.5.2 The current Header ID mappings defined by PKWARE are:
+    //
+    //    0x0001        Zip64 extended information extra field
+    //  [...]
+
+    // 4.5.3 -Zip64 Extended Information Extra Field (0x0001):
+    //
+    //       Note: all fields stored in Intel low-byte/high-byte order.
+    //
+    //         Value      Size       Description
+    //         -----      ----       -----------
+    // (ZIP64) 0x0001     2 bytes    Tag for this "extra" block type
+    //         Size       2 bytes    Size of this "extra" block
+    //         Original
+    //         Size       8 bytes    Original uncompressed file size
+    //         Compressed
+    //         Size       8 bytes    Size of compressed data
+    //         Relative Header
+    //         Offset     8 bytes    Offset of local header record
+    //         Disk Start
+    //         Number     4 bytes    Number of the disk on which
+    //                               this file starts
+
+    // ZIP64 extension
+    dst.extend_from_slice(&1u16.to_le_bytes());
+    // We have 16 bytes of extra data
+    dst.extend_from_slice(&16u16.to_le_bytes());
+    // Uncompressed size
+    dst.extend_from_slice(&size.to_le_bytes());
+    // Compressed size
+    dst.extend_from_slice(&size.to_le_bytes());
+    // Other stuff is only for the central directory.
+
+    debug_assert_eq!(dst.len(), expected_size);
+    dst
+}
+
+/// Constructs the central (end of file) "header" for `filename`'s contents with header at
+/// offset `header_offset` and *file size* `size`.
+///
+/// If `filename` exceeds u16::MAX bytes, it is truncated silently.
+pub fn construct_central_directory_header(
+    filename: &str,
+    header_offset: u64,
+    size: u64,
+    mut dst: Vec<u8>,
+) -> Vec<u8> {
+    // XXX: silently clamp the filename, we can't have paths that long
+    // in real life.
+    let filename_len: u16 = filename.as_bytes().len().min(u16::MAX as usize) as u16;
+    let filename = &filename.as_bytes()[..filename_len as usize];
+
+    let initial_len = dst.len();
+    let expected_size = 46 + filename.len() + 28;
+    let _ = dst.try_reserve(expected_size);
+
+    // 4.3.12  Central directory structure
+    //   File header:
+
+    // central file header signature   4 bytes  (0x02014b50)
+    // version made by                 2 bytes
+    // version needed to extract       2 bytes
+    // general purpose bit flag        2 bytes
+    // compression method              2 bytes
+    // last mod file time              2 bytes
+    // last mod file date              2 bytes
+    // crc-32                          4 bytes
+    // compressed size                 4 bytes
+    // uncompressed size               4 bytes
+    // file name length                2 bytes
+    // extra field length              2 bytes
+    // file comment length             2 bytes
+    // disk number start               2 bytes
+    // internal file attributes        2 bytes
+    // external file attributes        4 bytes
+    // relative offset of local header 4 bytes
+
+    // file name (variable size)
+    // extra field (variable size)
+    // file comment (variable size)
+
+    // Signature
+    dst.extend_from_slice(b"PK\x01\x02");
+    // Writer version 4.5
+    dst.extend_from_slice(&45u16.to_le_bytes());
+    // Reader version 4.5 (for Zip64)
+    dst.extend_from_slice(&45u16.to_le_bytes());
+    // Flags
+    dst.extend_from_slice(&0u16.to_le_bytes());
+    // Compression method (STORE)
+    dst.extend_from_slice(&0u16.to_le_bytes());
+    // Time
+    dst.extend_from_slice(&0u16.to_le_bytes());
+    // Date
+    dst.extend_from_slice(&0u16.to_le_bytes());
+    // CRC
+    dst.extend_from_slice(&0u32.to_le_bytes());
+    // Uncompressed size (escape to zip64)
+    dst.extend_from_slice(&u32::MAX.to_le_bytes());
+    // Compressed size (escape to zip64)
+    dst.extend_from_slice(&u32::MAX.to_le_bytes());
+    // Filename length
+    dst.extend_from_slice(&filename_len.to_le_bytes());
+    // Extra data (zip64)
+    dst.extend_from_slice(&28u16.to_le_bytes());
+    // Comment length
+    dst.extend_from_slice(&0u16.to_le_bytes());
+    // Disk number
+    dst.extend_from_slice(&0u16.to_le_bytes());
+    // Internal attributes
+    dst.extend_from_slice(&0u16.to_le_bytes());
+    // External attributes
+    dst.extend_from_slice(&0u32.to_le_bytes());
+    // Offset of local header (escape to zip64)
+    dst.extend_from_slice(&u32::MAX.to_le_bytes());
+
+    dst.extend_from_slice(filename);
+
+    // 4.5.3 -Zip64 Extended Information Extra Field (0x0001):
+    //
+    //       Note: all fields stored in Intel low-byte/high-byte order.
+    //
+    //         Value      Size       Description
+    //         -----      ----       -----------
+    // (ZIP64) 0x0001     2 bytes    Tag for this "extra" block type
+    //         Size       2 bytes    Size of this "extra" block
+    //         Original
+    //         Size       8 bytes    Original uncompressed file size
+    //         Compressed
+    //         Size       8 bytes    Size of compressed data
+    //         Relative Header
+    //         Offset     8 bytes    Offset of local header record
+    //         Disk Start
+    //         Number     4 bytes    Number of the disk on which
+    //                               this file starts
+
+    // Zip64 extension
+    dst.extend_from_slice(&1u16.to_le_bytes());
+    // 24 byte payload
+    dst.extend_from_slice(&24u16.to_le_bytes());
+    // Uncompressed size
+    dst.extend_from_slice(&size.to_le_bytes());
+    // Compressed size
+    dst.extend_from_slice(&size.to_le_bytes());
+    // Header start
+    dst.extend_from_slice(&header_offset.to_le_bytes());
+
+    debug_assert_eq!(dst.len() - initial_len, expected_size);
+    dst
+}
+
+/// Constructs the locator trailer for a central directory of `num_records`
+/// starting at `central_directory_offset` and spanning `central_directory_bytes`.
+///
+/// We expect the locator to be written at `dst_offset`, or right
+/// after the central directory records by default.
+pub fn construct_central_directory_locator(
+    num_records: usize,
+    central_directory_offset: u64,
+    central_directory_bytes: u64,
+    dst_offset: Option<u64>,
+    mut dst: Vec<u8>,
+) -> Vec<u8> {
+    let dst_offset =
+        dst_offset.unwrap_or(central_directory_offset.saturating_add(central_directory_bytes));
+
+    let initial_len = dst.len();
+    let expected_size = 56 + 20 + 22;
+    let _ = dst.try_reserve(expected_size);
+
+    // 4.3.14  Zip64 end of central directory record
+    //
+    //      zip64 end of central dir
+    //      signature                       4 bytes  (0x06064b50)
+    //      size of zip64 end of central
+    //      directory record                8 bytes
+    //      version made by                 2 bytes
+    //      version needed to extract       2 bytes
+    //      number of this disk             4 bytes
+    //      number of the disk with the
+    //      start of the central directory  4 bytes
+    //      total number of entries in the
+    //      central directory on this disk  8 bytes
+    //      total number of entries in the
+    //      central directory               8 bytes
+    //      size of the central directory   8 bytes
+    //      offset of start of central
+    //      directory with respect to
+    //      the starting disk number        8 bytes
+    //      zip64 extensible data sector    (variable size)
+    //
+    //    4.3.14.1 The value stored into the "size of zip64 end of central
+    //    directory record" SHOULD be the size of the remaining
+    //    record and SHOULD NOT include the leading 12 bytes.
+    //
+    //    Size = SizeOfFixedFields + SizeOfVariableData - 12.
+
+    // Signature (ZIP64)
+    dst.extend_from_slice(b"PK\x06\x06");
+    // Size of record
+    dst.extend_from_slice(&44u64.to_le_bytes());
+    // Writer version 4.5
+    dst.extend_from_slice(&45u16.to_le_bytes());
+    // Reader version 4.5 (for Zip64)
+    dst.extend_from_slice(&45u16.to_le_bytes());
+    // Disk number
+    dst.extend_from_slice(&0u32.to_le_bytes());
+    // Disk number for central directory
+    dst.extend_from_slice(&0u32.to_le_bytes());
+    // Number of central directory records on "this disk"
+    dst.extend_from_slice(&(num_records as u64).to_le_bytes());
+    // Number of central directory records in total
+    dst.extend_from_slice(&(num_records as u64).to_le_bytes());
+    dst.extend_from_slice(&central_directory_bytes.to_le_bytes());
+    dst.extend_from_slice(&central_directory_offset.to_le_bytes());
+
+    // 4.3.15 Zip64 end of central directory locator
+    //
+    //    zip64 end of central dir locator
+    //    signature                       4 bytes  (0x07064b50)
+    //    number of the disk with the
+    //    start of the zip64 end of
+    //    central directory               4 bytes
+    //    relative offset of the zip64
+    //    end of central directory record 8 bytes
+    //    total number of disks           4 bytes
+
+    // ZIP64 locator
+    dst.extend_from_slice(b"PK\x06\x07");
+    // Disk number
+    dst.extend_from_slice(&0u32.to_le_bytes());
+    dst.extend_from_slice(&dst_offset.to_le_bytes());
+    // Total number of disks (1)
+    dst.extend_from_slice(&1u32.to_le_bytes());
+
+    // 4.3.16  End of central directory record:
+    //
+    //    end of central dir signature    4 bytes  (0x06054b50)
+    //    number of this disk             2 bytes
+    //    number of the disk with the
+    //    start of the central directory  2 bytes
+    //    total number of entries in the
+    //    central directory on this disk  2 bytes
+    //    total number of entries in
+    //    the central directory           2 bytes
+    //    size of the central directory   4 bytes
+    //    offset of start of central
+    //    directory with respect to
+    //    the starting disk number        4 bytes
+    //    .ZIP file comment length        2 bytes
+    //    .ZIP file comment       (variable size)
+
+    // End of record locator
+    dst.extend_from_slice(b"PK\x05\x06");
+    // Disk number
+    dst.extend_from_slice(&0u16.to_le_bytes());
+    // Disk with directory
+    dst.extend_from_slice(&0u16.to_le_bytes());
+    // Number of CDR entries on disk(defer to zip64)
+    dst.extend_from_slice(&u16::MAX.to_le_bytes());
+    // Number of CDR entries in total (defer to zip64)
+    dst.extend_from_slice(&u16::MAX.to_le_bytes());
+    // Size of central directory (defer to zip64)
+    dst.extend_from_slice(&u32::MAX.to_le_bytes());
+    // Offset of central directory (defer to zip64)
+    dst.extend_from_slice(&u32::MAX.to_le_bytes());
+    // Comment size (0)
+    dst.extend_from_slice(&0u16.to_le_bytes());
+
+    debug_assert_eq!(dst.len() - initial_len, expected_size);
+    dst
+}

--- a/trivial_zip_wrapper/src/lib.rs
+++ b/trivial_zip_wrapper/src/lib.rs
@@ -1,0 +1,366 @@
+//! The `trivial_zip_wrapper` crate wraps uncompressed ("`STORE`d")
+//! files in ZIP-compatible metadata.  The one incompatibility is
+//! that, in order to enable in-kernel copies, the CRC field is left
+//! zeroed-out.
+pub mod headers;
+
+use std::io::Result;
+
+/// A `ZipWrapperWriter` emits trivial STORED data in a Zip container.
+///
+/// The implementation avoids reading the source data (doesn't even
+/// compute a CRC) to enable in-kernel copies.
+#[derive(Debug)]
+pub struct ZipWrapperWriter<F>
+where
+    F: std::io::Write + std::fmt::Debug,
+{
+    // One entry for each written file, with the name as the first
+    // value, followed by the offset *of the local file header*
+    // and the size *of the file*.
+    contents: Vec<(String, u64, u64)>,
+    written_so_far: u64,
+    // All writes to `destination` must update `written_so_far`.
+    destination: F,
+}
+
+impl<F> ZipWrapperWriter<F>
+where
+    F: std::io::Write + std::fmt::Debug,
+{
+    /// Creates a new `ZipWrapperWriter` that appends to `destination`.
+    pub fn new(destination: F, initial_offset: u64) -> Self {
+        Self {
+            contents: Vec::new(),
+            written_so_far: initial_offset,
+            destination,
+        }
+    }
+
+    /// Adds an entry for file `name` with `size` bytes from `payload` as the contents.
+    pub fn copy_file(
+        &mut self,
+        name: String,
+        payload: impl std::io::Read,
+        size: u64,
+    ) -> Result<()> {
+        self.copy_file_impl(
+            headers::construct_local_file_header(&name, size),
+            name,
+            payload,
+            size,
+        )
+    }
+
+    fn copy_file_impl(
+        &mut self,
+        header: Vec<u8>,
+        name: String,
+        payload: impl std::io::Read,
+        size: u64,
+    ) -> Result<()> {
+        let offset = self.written_so_far;
+        self.destination.write_all(&header)?;
+        self.written_so_far += header.len() as u64;
+
+        let copied = std::io::copy(&mut payload.take(size), &mut self.destination)?;
+        self.written_so_far += copied;
+        if copied != size {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "Short ZipWrapperWriter::copy_file",
+            ));
+        }
+
+        self.contents.push((name, offset, size));
+        Ok(())
+    }
+
+    /// Terminates the zip file and returns the output file on success.
+    pub fn finish(mut self) -> Result<F> {
+        // Reserve at least 80 bytes per file, and 100 bytes for the locators.
+        let mut dst: Vec<u8> =
+            Vec::with_capacity(self.contents.len().saturating_mul(80).saturating_add(100));
+
+        for (name, offset, size) in self.contents.iter() {
+            dst = headers::construct_central_directory_header(name, *offset, *size, dst);
+        }
+
+        let directory_size = dst.len() as u64;
+        dst = headers::construct_central_directory_locator(
+            self.contents.len(),
+            self.written_so_far,
+            directory_size,
+            None,
+            dst,
+        );
+
+        self.destination.write_all(&dst)?;
+        Ok(self.destination)
+    }
+}
+
+fn compute_padding(
+    written_so_far: u64,
+    header_size: usize,
+    payload_alignment: u32,
+    max_padding: u32,
+) -> u32 {
+    let payload_alignment = payload_alignment.max(1); // avoid division by 0
+
+    let current_destination = written_so_far + header_size as u64;
+    let current_misalignment = (current_destination % (payload_alignment as u64)) as u32;
+
+    let mut padding = (payload_alignment - current_misalignment) % payload_alignment;
+
+    while padding > max_padding {
+        // Zero out the top bit to shrink `padding` while maximally preserving
+        // zeroed out low bits in `written_so_far + header_size + padding`.
+        padding -= 1u32 << padding.ilog2();
+    }
+
+    padding
+}
+
+impl<F> ZipWrapperWriter<F>
+where
+    F: std::io::Write + std::io::Seek + std::fmt::Debug,
+{
+    /// Like [`Self::copy_file`], except the payload is aligned to
+    /// `payload_alignment`, or as close as possible without exceeding
+    /// `max_padding`.
+    ///
+    /// The `payload_alignment` should be a power of 2, but other
+    /// values will not crash.
+    ///
+    /// The padding will inserted before the zip local header, so the
+    /// output is still a valid Zip file.
+    pub fn copy_file_aligned(
+        &mut self,
+        name: String,
+        payload: impl std::io::Read,
+        size: u64,
+        payload_alignment: u32,
+        max_padding: u32,
+    ) -> Result<()> {
+        let header = headers::construct_local_file_header(&name, size);
+
+        let padding = compute_padding(
+            self.written_so_far,
+            header.len(),
+            payload_alignment,
+            max_padding,
+        );
+        if padding > 0 {
+            self.destination
+                .seek(std::io::SeekFrom::Current(padding as i64))?;
+            self.written_so_far += padding as u64;
+        }
+
+        self.copy_file_impl(header, name, payload, size)
+    }
+}
+
+#[test]
+fn test_compute_padding() {
+    let header_size = 63usize;
+
+    for current_offset in 0..if cfg!(miri) { 30 } else { 1000 } {
+        for lg_alignment in 0..8 {
+            for max_padding in 0..300 {
+                let alignment = 1u32 << lg_alignment;
+                let padding = compute_padding(current_offset, header_size, alignment, max_padding);
+                assert!(padding <= max_padding);
+
+                // If we didn't pad
+                let baseline_position = current_offset + header_size as u64;
+                let next = baseline_position.next_multiple_of(alignment as u64);
+                if next - baseline_position <= max_padding as u64 || alignment <= max_padding {
+                    // We'll start the payload write at current_offset + padding + header_size;
+                    // that should be aligned!
+                    assert_eq!(
+                        (current_offset + padding as u64 + header_size as u64) % alignment as u64,
+                        0
+                    );
+                }
+
+                // Don't make things worse.
+                let padded_position = baseline_position + padding as u64;
+                assert!(padded_position.trailing_zeros() >= baseline_position.trailing_zeros());
+                if padding > 0 {
+                    assert!(padded_position.trailing_zeros() > baseline_position.trailing_zeros());
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test_zipper_wrapper_trivial_miri() {
+    let mut writer = ZipWrapperWriter::new(Vec::new(), 0);
+
+    // Replicate https://blog.yaakov.online/zip64-go-big-or-go-home/
+
+    writer
+        .copy_file("README.txt".to_owned(), &b"Hello, World!"[..], 13)
+        .expect("should work");
+
+    let output = writer.finish().expect("should succeed");
+    let expected: Vec<&[u8]> = vec![
+        b"PK\x03\x04",       // signature
+        b"\x2d\x00",         // version
+        b"\x00\x00",         // flags
+        b"\x00\x00",         // STORED
+        b"\x00\x00",         // Time
+        b"\x00\x00",         // Date
+        b"\x00\x00\x00\x00", // CRC [ DUMMY ]
+        b"\xFF\xFF\xFF\xFF", // dummy size
+        b"\xFF\xFF\xFF\xFF", // dummy size
+        b"\x0a\x00",         // 10 chars (README.txt)
+        b"\x14\x00",         // 20 bytes for extra zip64 data
+        b"README.txt",       // Filename
+        b"\x01\x00",         // Zip64 tag
+        b"\x10\x00",         // 16 bytes of zip64 data
+        b"\x0d\x00\x00\x00", // 13 bytes of data
+        b"\x00\x00\x00\x00",
+        b"\x0d\x00\x00\x00", // 13 bytes of data
+        b"\x00\x00\x00\x00",
+        b"Hello, World!",    // Data
+        b"PK\x01\x02",       // Directory record signature
+        b"\x2d\x00",         // Version
+        b"\x2d\x00",         // Version
+        b"\x00\x00",         // Flags
+        b"\x00\x00",         // STORED
+        b"\x00\x00",         // Time
+        b"\x00\x00",         // Date,
+        b"\x00\x00\x00\x00", // CRC [ DUMMY ]
+        b"\xFF\xFF\xFF\xFF", // dummy size
+        b"\xFF\xFF\xFF\xFF", // dummy size
+        b"\x0a\x00",         // 10-char name
+        b"\x1c\x00",         // 28 extra bytes for zip64
+        b"\x00\x00",         // 0 comment bytes
+        b"\x00\x00",         // disk number
+        b"\x00\x00",         // internal attributes
+        b"\x00\x00\x00\x00", // external attributes
+        b"\xff\xff\xff\xff", // dummy offset
+        b"README.txt",       // filename
+        b"\x01\x00",         // Zip64 tag
+        b"\x18\x00",         // size of zip64 data
+        b"\x0d\x00\x00\x00", // 13 bytes of data
+        b"\x00\x00\x00\x00",
+        b"\x0d\x00\x00\x00", // 13 bytes of data
+        b"\x00\x00\x00\x00",
+        b"\x00\x00\x00\x00", // Header offfset
+        b"\x00\x00\x00\x00",
+        b"PK\x06\x06",       // Zip64 end of directory records signature
+        b"\x2c\x00\x00\x00", // Size of CDR
+        b"\x00\x00\x00\x00",
+        b"\x2d\x00",         // Version
+        b"\x2d\x00",         // Version
+        b"\x00\x00\x00\x00", // Disk number
+        b"\x00\x00\x00\x00", // Disk number
+        b"\x01\x00\x00\x00", // Number of records
+        b"\x00\x00\x00\x00",
+        b"\x01\x00\x00\x00", // Number of records
+        b"\x00\x00\x00\x00",
+        b"\x54\x00\x00\x00", // Size of central directory
+        b"\x00\x00\x00\x00",
+        b"\x49\x00\x00\x00", // Offset of central directory
+        b"\x00\x00\x00\x00",
+        b"PK\x06\x07",       // Zip64 end of central directory signature
+        b"\x00\x00\x00\x00", // disk number
+        b"\x9d\x00\x00\x00", // Offset of Zip64 EOCD signature
+        b"\x00\x00\x00\x00",
+        b"\x01\x00\x00\x00", // disk count
+        b"PK\x05\x06",       // Regular end of central directory signature
+        b"\x00\x00",         // disk number
+        b"\x00\x00",         // disk number
+        b"\xff\xff",         // Dummy # entries
+        b"\xff\xff",         // Dummy # entries
+        b"\xff\xff\xff\xff", // dummy size of central directory
+        b"\xff\xff\xff\xff", // dummy offset of central directory
+        b"\x00\x00",         // Comment size
+    ];
+
+    assert_eq!(output, expected.concat());
+
+    let mut writer = ZipWrapperWriter::new(std::io::Cursor::new(Vec::new()), 0);
+    writer
+        .copy_file_aligned("README.txt".to_owned(), &b"Hello, World!"[..], 13, 64, 64)
+        .expect("should work");
+
+    let padded_output = writer.finish().expect("should succeed").into_inner();
+    // The offsets in the central directory will differ, but the local header should be same,
+    // modulo padding.
+    assert_eq!(&padded_output[..128], [&[0u8; 4], &output[..124]].concat());
+    assert_ne!(&padded_output[..], [&[0u8; 4], &output[..]].concat());
+
+    // And the payload should be at an aligned position.
+    assert_eq!(&padded_output[64..77], b"Hello, World!");
+}
+
+// Check that the `zip` crate can decode the headers.
+#[test]
+fn test_roundtrip_miri() {
+    use std::collections::BTreeSet;
+    use std::io::Cursor;
+    use std::io::Read;
+
+    let mut writer = ZipWrapperWriter::new(std::io::Cursor::new(Vec::new()), 0);
+
+    {
+        let payload = b"FIRST_LOG_DATA";
+        writer
+            .copy_file("FIRST.log".to_owned(), &payload[..], payload.len() as u64)
+            .expect("should succeed");
+    }
+
+    {
+        let payload = b"SECOND_LOG_DATA";
+        writer
+            .copy_file_aligned(
+                "SECOND.log".to_owned(),
+                &payload[..],
+                payload.len() as u64,
+                1024,
+                1024,
+            )
+            .expect("should succeed");
+    }
+
+    let result = writer.finish().expect("should succeed").into_inner();
+
+    let mut reader = zip::read::ZipArchive::new(Cursor::new(&result[..])).expect("should succeed");
+    assert_eq!(reader.len(), 2);
+
+    assert_eq!(
+        reader.file_names().collect::<BTreeSet<_>>(),
+        vec!["FIRST.log", "SECOND.log"]
+            .into_iter()
+            .collect::<BTreeSet<_>>()
+    );
+
+    {
+        let mut file = reader.by_name("FIRST.log").expect("should locate fine");
+
+        assert!(file.is_file());
+
+        let mut dst = Vec::new();
+        // CRC fails at the end.
+        assert!(file.read_to_end(&mut dst).is_err());
+        assert_eq!(&dst[..], b"FIRST_LOG_DATA");
+    }
+
+    {
+        let mut file = reader.by_name("SECOND.log").expect("should locate fine");
+
+        assert!(file.is_file());
+        // Data offset should be aligned
+        assert_eq!(file.data_start() % 1024, 0);
+
+        let mut dst = Vec::new();
+        // CRC fails at the end.
+        assert!(file.read_to_end(&mut dst).is_err());
+        assert_eq!(&dst[..], b"SECOND_LOG_DATA");
+    }
+}


### PR DESCRIPTION
We want to use the zip file format as a container of raw bytes (in uncompressed STORED format).  We also want to do that for input files that live on NFS.  Copying from NFS with a read(2)/write(2) loop is usually latency-bound, so we instead want to stick the input bytes in the zip container with `std::io::copy`, which can then use `copy_file_range` or similar accelerated kernel/server-side copies.

The trivial_zip_wrapper does that, in zip64 format.  Of course, if we don't want to actually read the data, we can't compute its CRC, so the checksum fields are always corrupt (0).  The rest of the zip is valid though, so we can use standard readers as long as we don't check for corruption or the check happens late enough.  We should even be able to "fix" the archives and decompress them at the command line.

Some filesystems also benefit from logical alignment.  For example, ZFS can (in some configurations) use record-level Copy-on-Write when the source and destinations's logical offsets are aligned to the record size (128 KB by default).  Entries in a zip file can be separated by arbitrary data, so the `trivial_zip_wrapper` crate supports such alignment, by padding *before* the local header (the payload must always come immediately after the local header).

Compare the code in headers.rs with the quoted sections of the PKWARE app note, then lib.rs.  The only interesting thing in lib.rs is the computating to insert padding before the local file header, to ensure the *payload* is correctly aligned.