### PR TITLE
Add hcobs crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 
 members = [
+  "hcobs",
   "owning_iovec",
   "sliding_deque",
 ]

--- a/hcobs/Cargo.toml
+++ b/hcobs/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "hcobs"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+owning_iovec = { path = "../owning_iovec" }
+
+[dev-dependencies]
+rusty-fork = "0.3"
+
+[lints]
+workspace = true

--- a/hcobs/examples/hcobs.rs
+++ b/hcobs/examples/hcobs.rs
@@ -1,0 +1,103 @@
+//! hcobs codec: decodes if argv[1] starts with "d", encodes otherwise
+use std::io::Result;
+use std::io::Write;
+use std::num::NonZeroUsize;
+
+const BUFSZ: usize = 512 * 1024;
+
+fn decode() -> Result<()> {
+    let mut decoder = hcobs::Decoder::new();
+    let mut stdin = std::io::stdin().lock();
+    let mut stdout = std::io::stdout().lock();
+
+    let mut flush = |mut consumer: owning_iovec::ConsumingIovec, ret: Result<()>| -> Result<()> {
+        loop {
+            let prefix = consumer.stable_prefix();
+            if prefix.is_empty() {
+                return ret;
+            }
+
+            match stdout.write_vectored(prefix) {
+                Ok(0) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "failed to write to stdout",
+                    ))
+                }
+                Ok(n) => assert_eq!(consumer.advance_slices(n), n),
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+    };
+
+    loop {
+        match decoder.decode_read(&mut stdin, BUFSZ, NonZeroUsize::new(100).unwrap()) {
+            Ok(0) => {
+                return flush(
+                    decoder.finish().map_err(std::io::Error::other)?.consumer(),
+                    Ok(()),
+                )
+            }
+            Err(e) if e.kind() != std::io::ErrorKind::Interrupted => {
+                return flush(
+                    decoder.finish().map_err(std::io::Error::other)?.consumer(),
+                    Err(e),
+                )
+            }
+            _ => flush(decoder.consumer(), Ok(()))?,
+        }
+    }
+}
+
+fn encode() -> Result<()> {
+    let mut encoder = hcobs::Encoder::new();
+    let mut stdin = std::io::stdin().lock();
+    let mut stdout = std::io::stdout().lock();
+
+    let mut flush = |mut consumer: owning_iovec::ConsumingIovec, ret: Result<()>| -> Result<()> {
+        loop {
+            let prefix = consumer.stable_prefix();
+            if prefix.is_empty() {
+                return ret;
+            }
+
+            match stdout.write_vectored(prefix) {
+                Ok(0) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "failed to write to stdout",
+                    ))
+                }
+                Ok(n) => assert_eq!(consumer.advance_slices(n), n),
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+    };
+
+    loop {
+        match encoder.encode_read(&mut stdin, BUFSZ, NonZeroUsize::new(100).unwrap()) {
+            Ok(0) => return flush(encoder.finish().consumer(), Ok(())),
+            Err(e) if e.kind() != std::io::ErrorKind::Interrupted => {
+                return flush(encoder.finish().consumer(), Err(e))
+            }
+            _ => flush(encoder.consumer(), Ok(()))?,
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+
+    if args
+        .get(1)
+        .map(|x| -> &str { x })
+        .unwrap_or("")
+        .starts_with('d')
+    {
+        decode()
+    } else {
+        encode()
+    }
+}

--- a/hcobs/examples/noop.rs
+++ b/hcobs/examples/noop.rs
@@ -1,0 +1,23 @@
+//! noop encoder: reads bytes from stdin and writes them to stdout
+use std::io::Result;
+
+const BUFSZ: usize = 512 * 1024;
+
+fn main() -> Result<()> {
+    use std::io::Read;
+    use std::io::Write;
+    let mut buf = vec![0u8; BUFSZ];
+    let mut stdin = std::io::stdin().lock();
+    let mut stdout = std::io::stdout().lock();
+
+    loop {
+        match stdin.read(&mut buf) {
+            Ok(0) => break,
+            Ok(count) => stdout.write_all(&buf[..count])?,
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
+    }
+
+    Ok(())
+}

--- a/hcobs/src/decoder.rs
+++ b/hcobs/src/decoder.rs
@@ -1,0 +1,600 @@
+use crate::Parameters;
+use crate::RADIX;
+use crate::STUFF_SEQUENCE;
+#[cfg(test)]
+use crate::TEST_PARAMS;
+
+use std::num::NonZeroU32;
+
+use owning_iovec::OwningIovec;
+
+/// The initial state for the HCOBS decoder.  We're expecting the first chunk
+/// of data.
+///
+/// The initial state is special because the first chunk has a one-byte size
+/// header.
+#[derive(Debug, Eq, PartialEq)]
+pub struct InitialState {}
+
+/// The other reset state for the HCOBS decoder, between chunks.  We're
+/// waiting for a subsequent (not the first) chunk of data.
+///
+/// Subsequent chunks differ from the initial chunk because they have a
+/// two-byte size header. The `should insert_stuff_sequence` field indicates
+/// whether a `STUFF_SEQUENCE` should be inserted at the start of the next
+/// chunk.  We don't producer the `STUFF_SEQUENCE` eagerly because the last
+/// one in an encoded sequence is an fake sequence that acts as a terminator.
+#[derive(Debug, Eq, PartialEq)]
+pub struct BeforeChunk {
+    should_insert_stuff_sequence: bool,
+}
+
+/// The state of the HCOBS decoder after processing the first byte of a chunk
+/// size header; that first byte is stored in `initial_byte`.
+#[derive(Debug, Eq, PartialEq)]
+pub struct MidHeader {
+    initial_byte: u8,
+}
+
+/// The state of the HCOBS decoder when decoding a size-prefixed chunk.
+///
+/// The `remaining` field indicates the number of bytes remaining in the
+/// current chunk, and the `terminate_with_stuff_sequence` field indicates
+/// whether the chunk should be terminated with a `STUFF_SEQUENCE`.
+#[derive(Debug, Eq, PartialEq)]
+pub struct InChunk {
+    remaining: NonZeroU32,
+    terminate_with_stuff_sequence: bool,
+}
+
+/// Represents the different states of the HCOBS decoder during the decoding
+/// process.
+#[derive(Debug, Eq, PartialEq)]
+pub enum DecoderState {
+    InitialState(InitialState),
+    BeforeChunk(BeforeChunk),
+    MidHeader(MidHeader),
+    InChunk(InChunk),
+}
+
+/// Failure reasons for decoding with [`Decoder`]
+///
+/// HCOBS-encoded data is partitioned in length-value segments, where the
+/// values are arbitrary (they *shouldn't* contain the [`STUFF_SEQUENCE`], but
+/// that's irrelevant for decoding).  The only validation happens for the
+/// length headers: lengths are in radix-253, so high bytes are invalid.  We
+/// also expect the HCOBS-encoded value to end exactly at a segment with an
+/// implicit [`STUFF_SEQUENCE`] at the end, so short inputs can also error
+/// out.
+///
+/// This format is robust, and there are many ways for a corrupt or truncated
+/// encoded stream to still decode correctly. Encoded data should come with a
+/// checksum mechanism (e.g., embedded in each encoded payload).
+///
+/// [`Decoder`]: [`crate::Decoder`]
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub enum DecodingError {
+    /// The first byte in an HCOBS-encoded stream must be a 1-byte
+    /// size header for the initial segment.  This value is in radix
+    /// 253, so 253, 254, and 255 are invalid.
+    ///
+    /// The payload is the invalid byte.
+    InvalidInitialSizeHeader(u8),
+    /// Subsequent segments start with a 2-byte (little-endian) size header,
+    /// in radix 253 again.  The payload is the index of the byte, and
+    /// the invalid byte value.
+    InvalidHeaderByte((bool, u8)),
+    /// In test configurations, a 2-byte size header may be a valid radix-253
+    /// value but too large for a size header.
+    ///
+    /// The payload is that invalid size.
+    InvalidSubsequentSizeHeader(usize),
+    /// We expect input streams to end at a segment boundary.  It's an error
+    /// if the stream ends and we're not waiting for the first byte in a
+    /// chunk header.
+    CutShort,
+    /// We expect input streams to end after a short (less than maximum length)
+    /// segment: these segments denote an implicit [`STUFF_SEQUENCE`] between
+    /// the segment that just ended and the next.  For the final segment, it
+    /// simply means that we correctly reached the end.
+    MissingImplicitTerminator,
+}
+
+impl std::fmt::Display for DecodingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use DecodingError::*;
+        match self {
+            InvalidInitialSizeHeader(byte) => write!(
+                f,
+                "HCOBS decoding error: invalid initial chunk size. byte={}",
+                byte
+            ),
+            InvalidHeaderByte((second, byte)) => write!(
+                f,
+                "HCOBS decoding error: invalid subsequent chunk header byte. index={} byte={}",
+                *second as u8, byte
+            ),
+            InvalidSubsequentSizeHeader(size) => write!(
+                f,
+                "HCOBS decoding error: invalid subsequent size. size={}",
+                size
+            ),
+            CutShort => write!(f, "HCOBS decoding error: decoding terminated mid-chunk"),
+            MissingImplicitTerminator => write!(f, "HCOBS decoding error: decoding terminated without implicit stuff sequence terminator"),
+        }
+    }
+}
+
+impl std::error::Error for DecodingError {}
+
+pub type Result<T> = std::result::Result<T, DecodingError>;
+
+impl Default for DecoderState {
+    #[inline(always)]
+    fn default() -> Self {
+        DecoderState::new()
+    }
+}
+
+impl DecoderState {
+    /// Creates a new `DecoderState` in the initial state.
+    #[inline(always)]
+    pub fn new() -> DecoderState {
+        DecoderState::InitialState(InitialState {})
+    }
+
+    /// Terminates the decoding process.
+    ///
+    /// Returns an error if the decoder was not stopped at the end of a chunk
+    /// with an implicit stuff sequence terminator (i.e., was stopped early).
+    #[inline(always)]
+    pub fn terminate(self) -> Result<()> {
+        match self {
+            DecoderState::BeforeChunk(state) => {
+                if state.should_insert_stuff_sequence {
+                    // We must have a stuff sequence pending if we terminate
+                    Ok(())
+                } else {
+                    Err(DecodingError::MissingImplicitTerminator)
+                }
+            }
+            _ => Err(DecodingError::CutShort),
+        }
+    }
+
+    /// Decodes the contents of an input slice into an [`OwningIovec`].
+    ///
+    /// Returns an error if there is any decoding error, otherwise consumes
+    /// the whole slice.
+    pub fn decode_borrow<'slices>(
+        mut self,
+        iovec: &mut OwningIovec<'slices>,
+        params: Parameters,
+        mut input: &'slices [u8],
+    ) -> Result<Self> {
+        while !input.is_empty() {
+            let consumed;
+
+            // Each `decode` call advances the state machine by one state.
+            (self, consumed) = match self {
+                DecoderState::InitialState(state) => state.decode(iovec, params, input)?,
+                DecoderState::BeforeChunk(state) => state.decode(iovec, params, input)?,
+                DecoderState::MidHeader(state) => state.decode(iovec, params, input)?,
+                DecoderState::InChunk(state) => state.decode_borrow(iovec, params, input),
+            };
+
+            input = &input[consumed..];
+        }
+
+        Ok(self)
+    }
+
+    /// Decodes the contents of an input slice into an [`OwningIovec`], while
+    /// unconditionally copying bytes into fresh slices owned by `iovec`.
+    ///
+    /// Returns an error if there is any decoding error, otherwise consumes
+    /// the whole slice.
+    pub fn decode_copy(
+        mut self,
+        iovec: &mut OwningIovec<'_>,
+        params: Parameters,
+        mut input: &[u8],
+    ) -> Result<Self> {
+        while !input.is_empty() {
+            let consumed;
+
+            (self, consumed) = match self {
+                DecoderState::InitialState(state) => state.decode(iovec, params, input)?,
+                DecoderState::BeforeChunk(state) => state.decode(iovec, params, input)?,
+                DecoderState::MidHeader(state) => state.decode(iovec, params, input)?,
+                DecoderState::InChunk(state) => state.decode_copy(iovec, params, input),
+            };
+
+            input = &input[consumed..];
+        }
+
+        Ok(self)
+    }
+}
+
+impl InitialState {
+    fn decode(
+        self,
+        _iovec: &mut OwningIovec<'_>,
+        params: Parameters,
+        input: &[u8],
+    ) -> Result<(DecoderState, usize)> {
+        assert!(!input.is_empty());
+
+        let chunk_size = input[0] as usize;
+        let max_initial_size: usize = params.max_initial_size.into();
+        if chunk_size > max_initial_size {
+            return Err(DecodingError::InvalidInitialSizeHeader(chunk_size as u8));
+        }
+
+        let terminate_with_stuff_sequence = chunk_size < max_initial_size;
+        if chunk_size > 0 {
+            Ok((
+                DecoderState::InChunk(InChunk {
+                    remaining: NonZeroU32::new(chunk_size as u32).unwrap(),
+                    terminate_with_stuff_sequence,
+                }),
+                1,
+            ))
+        } else {
+            Ok((
+                DecoderState::BeforeChunk(BeforeChunk {
+                    should_insert_stuff_sequence: terminate_with_stuff_sequence,
+                }),
+                1,
+            ))
+        }
+    }
+}
+
+impl BeforeChunk {
+    fn decode(
+        self,
+        iovec: &mut OwningIovec<'_>,
+        _params: Parameters,
+        input: &[u8],
+    ) -> Result<(DecoderState, usize)> {
+        assert!(!input.is_empty());
+
+        if self.should_insert_stuff_sequence {
+            iovec.push_copy(&STUFF_SEQUENCE);
+        }
+
+        let initial_byte = input[0];
+        if initial_byte as usize >= RADIX {
+            Err(DecodingError::InvalidHeaderByte((false, initial_byte)))
+        } else {
+            Ok((DecoderState::MidHeader(MidHeader { initial_byte }), 1))
+        }
+    }
+}
+
+impl MidHeader {
+    fn decode(
+        self,
+        _iovec: &mut OwningIovec<'_>,
+        params: Parameters,
+        input: &[u8],
+    ) -> Result<(DecoderState, usize)> {
+        assert!(!input.is_empty());
+
+        let second_byte = input[0] as usize;
+        if second_byte >= RADIX {
+            return Err(DecodingError::InvalidHeaderByte((true, second_byte as u8)));
+        }
+
+        let chunk_size = (self.initial_byte as usize) + (second_byte * RADIX);
+        let max_subsequent_size: usize = params.max_subsequent_size.into();
+
+        if chunk_size > max_subsequent_size {
+            return Err(DecodingError::InvalidSubsequentSizeHeader(chunk_size));
+        }
+
+        let terminate_with_stuff_sequence = chunk_size < max_subsequent_size;
+        if chunk_size > 0 {
+            Ok((
+                DecoderState::InChunk(InChunk {
+                    remaining: NonZeroU32::new(chunk_size as u32).unwrap(),
+                    terminate_with_stuff_sequence,
+                }),
+                1,
+            ))
+        } else {
+            Ok((
+                DecoderState::BeforeChunk(BeforeChunk {
+                    should_insert_stuff_sequence: terminate_with_stuff_sequence,
+                }),
+                1,
+            ))
+        }
+    }
+}
+
+impl InChunk {
+    fn update(mut self, bytes_consumed: usize) -> (DecoderState, usize) {
+        if bytes_consumed < self.remaining.get() as usize {
+            self.remaining = NonZeroU32::new(self.remaining.get() - bytes_consumed as u32).unwrap();
+            (DecoderState::InChunk(self), bytes_consumed)
+        } else {
+            assert_eq!(self.remaining.get(), bytes_consumed as u32);
+            let should_insert_stuff_sequence = self.terminate_with_stuff_sequence;
+            (
+                DecoderState::BeforeChunk(BeforeChunk {
+                    should_insert_stuff_sequence,
+                }),
+                bytes_consumed,
+            )
+        }
+    }
+
+    fn decode_borrow<'slices>(
+        self,
+        iovec: &mut OwningIovec<'slices>,
+        _params: Parameters,
+        input: &'slices [u8],
+    ) -> (DecoderState, usize) {
+        assert!(!input.is_empty());
+
+        let bytes_consumed = input.len().min(self.remaining.get() as usize);
+        iovec.push(&input[..bytes_consumed]);
+        self.update(bytes_consumed)
+    }
+
+    fn decode_copy(
+        self,
+        iovec: &mut OwningIovec<'_>,
+        _params: Parameters,
+        input: &[u8],
+    ) -> (DecoderState, usize) {
+        assert!(!input.is_empty());
+
+        let bytes_consumed = input.len().min(self.remaining.get() as usize);
+        iovec.push_copy(&input[..bytes_consumed]);
+        self.update(bytes_consumed)
+    }
+}
+
+#[cfg(test)]
+fn decode_with_test_params(bytes: &[u8]) -> Result<Vec<u8>> {
+    let decode_one = || {
+        let mut iovec = OwningIovec::new();
+        let mut decoder = DecoderState::new();
+
+        decoder = decoder.decode_borrow(&mut iovec, TEST_PARAMS, bytes)?;
+        decoder.terminate()?;
+
+        Ok(iovec.flatten().expect("no backpatch left"))
+    };
+
+    // Redundantly decode with copy and check it's the same result
+    let decode_two = || -> Result<Vec<u8>> {
+        let mut iovec = OwningIovec::new();
+        let mut decoder: DecoderState = Default::default();
+
+        for byte in bytes {
+            decoder = decoder.decode_copy(&mut iovec, TEST_PARAMS, &[*byte])?;
+        }
+
+        decoder.terminate()?;
+
+        Ok(iovec.flatten().expect("no backpatch left"))
+    };
+
+    let ret = decode_one();
+    let redundant = decode_two();
+
+    assert_eq!(ret.is_err(), redundant.is_err());
+    ret
+}
+
+// Test some expected input/output pairs
+#[test]
+fn test_simple_miri() {
+    assert_eq!(decode_with_test_params(b"\x00").unwrap(), b"");
+    assert_eq!(decode_with_test_params(b"\x011").unwrap(), b"1");
+    assert_eq!(decode_with_test_params(b"\x0212").unwrap(), b"12");
+    assert_eq!(decode_with_test_params(b"\x03123\x00\x00").unwrap(), b"123");
+    assert_eq!(
+        decode_with_test_params(b"\x03123\x04\x004567").unwrap(),
+        b"1234567"
+    );
+    assert_eq!(
+        decode_with_test_params(b"\x03123\x05\x0045678\x00\x00").unwrap(),
+        b"12345678"
+    );
+    assert_eq!(
+        decode_with_test_params(b"\x03123\x05\x0045678\x01\x009").unwrap(),
+        b"123456789"
+    );
+    assert_eq!(
+        decode_with_test_params(b"\x00\x00\x00").unwrap(),
+        b"\xFE\xFD"
+    );
+    assert_eq!(
+        decode_with_test_params(b"\x011\x00\x00").unwrap(),
+        b"1\xFE\xFD"
+    );
+    assert_eq!(
+        decode_with_test_params(b"\x0312\xFE\x01\x00\xFD").unwrap(),
+        b"12\xFE\xFD"
+    );
+    assert_eq!(
+        decode_with_test_params(b"\x03123\x00\x00\x00\x00").unwrap(),
+        b"123\xFE\xFD"
+    );
+    assert_eq!(
+        decode_with_test_params(b"\x03123\x01\x004\x01\x00\xFE").unwrap(),
+        b"1234\xFE\xFD\xFE"
+    );
+    assert_eq!(
+        decode_with_test_params(b"\x03123\x02\x004\xFE\x00\x00").unwrap(),
+        b"1234\xFE\xFE\xFD"
+    );
+    assert_eq!(
+        decode_with_test_params(b"\x03123\x04\x004\xFE\xFE\xFE").unwrap(),
+        b"1234\xFE\xFE\xFE"
+    );
+    assert_eq!(
+        decode_with_test_params(b"\x03123\x04\x004\xFD\xFD\xFD").unwrap(),
+        b"1234\xFD\xFD\xFD"
+    );
+}
+
+#[test]
+fn test_error_miri() {
+    // Bad initial header
+
+    // Truncated
+    assert!(decode_with_test_params(b"\x01").is_err());
+    // No terminating chunk
+    assert!(decode_with_test_params(b"\x03123").is_err());
+
+    // Bad radix
+    assert!(decode_with_test_params(b"\xff").is_err());
+    // Too long
+    assert!(decode_with_test_params(b"\x0f").is_err());
+
+    // Truncated first chunk
+    assert!(decode_with_test_params(b"\x021").is_err());
+
+    // No terminating chunk
+    assert!(decode_with_test_params(b"\x03123").is_err());
+
+    // Bad second header (first byte)
+    assert!(decode_with_test_params(b"\x03123\xff").is_err());
+
+    // Bad second header (second byte)
+    assert!(decode_with_test_params(b"\x03123\x00\xff").is_err());
+
+    // Bad second header (too large)
+    assert!(decode_with_test_params(b"\x03123\x00\x01").is_err());
+
+    // Truncated second chunk
+    assert!(decode_with_test_params(b"\x03123\x01\x00").is_err());
+
+    // No terminating chunk
+    assert!(decode_with_test_params(b"\x03123\x05\x0045678").is_err());
+}
+
+#[cfg(test)]
+fn compare_decode_with_test_params(
+    contiguous: &[u8],
+    initial: &[u8],
+    last: &[u8],
+    split: &[&[u8]],
+) {
+    let decode_zero = || -> Result<(DecoderState, Vec<u8>)> {
+        let mut iovec = OwningIovec::new();
+        let mut decoder = DecoderState::new();
+
+        decoder = decoder.decode_borrow(&mut iovec, TEST_PARAMS, contiguous)?;
+
+        Ok((decoder, iovec.flatten().expect("no backpatch left")))
+    };
+
+    let decode_one = || -> Result<(DecoderState, Vec<u8>)> {
+        let mut iovec = OwningIovec::new();
+        let mut decoder = DecoderState::new();
+
+        decoder = decoder.decode_borrow(&mut iovec, TEST_PARAMS, initial)?;
+        decoder = decoder.decode_borrow(&mut iovec, TEST_PARAMS, last)?;
+
+        Ok((decoder, iovec.flatten().expect("no backpatch left")))
+    };
+
+    let decode_two = || -> Result<(DecoderState, Vec<u8>)> {
+        let mut iovec = OwningIovec::new();
+        let mut decoder = DecoderState::new();
+
+        decoder = decoder.decode_copy(&mut iovec, TEST_PARAMS, initial)?;
+        for (idx, slice) in split.iter().enumerate() {
+            if (idx % 2) == 0 {
+                decoder = decoder.decode_borrow(&mut iovec, TEST_PARAMS, slice)?;
+            } else {
+                decoder = decoder.decode_copy(&mut iovec, TEST_PARAMS, slice)?;
+            }
+        }
+
+        Ok((decoder, iovec.flatten().expect("no backpatch left")))
+    };
+
+    let contiguous_result = decode_zero();
+    let first_result = decode_one();
+    let second_result = decode_two();
+
+    assert_eq!(contiguous_result.is_err(), first_result.is_err());
+    assert_eq!(first_result.is_err(), second_result.is_err());
+
+    if first_result.is_ok() {
+        let contiguous_result = contiguous_result.unwrap();
+        let first_result = first_result.unwrap();
+        let second_result = second_result.unwrap();
+
+        assert_eq!(contiguous_result, first_result);
+        assert_eq!(first_result, second_result);
+    }
+}
+
+// Start decoding up to `start`, the fork decoding (one incremental, one not),
+// and confirm we have the same final state.
+#[test]
+fn test_incremental_slow() {
+    let patterns = &[
+        b"\x03123\x02\x004\xFE\x00\x00",
+        b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09",
+        b"\x0212\x05\x0045678",
+        b"\x00\x05\x0045678\x00\x00",
+    ];
+
+    #[cfg(miri)]
+    let patterns = &patterns[..2];
+
+    for pattern in patterns {
+        for start in 0..pattern.len() {
+            for end in (start + 1)..=pattern.len() {
+                for mid in start..=end {
+                    compare_decode_with_test_params(
+                        &pattern[..end],
+                        &pattern[..start],
+                        &pattern[start..end],
+                        &[&pattern[start..mid], &pattern[mid..end]],
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test_error_display_miri() {
+    assert_eq!(
+        format!("{}", DecodingError::InvalidInitialSizeHeader(254)),
+        "HCOBS decoding error: invalid initial chunk size. byte=254"
+    );
+    assert_eq!(
+        format!("{}", DecodingError::InvalidHeaderByte((false, 255))),
+        "HCOBS decoding error: invalid subsequent chunk header byte. index=0 byte=255"
+    );
+    assert_eq!(
+        format!("{}", DecodingError::InvalidHeaderByte((true, 254))),
+        "HCOBS decoding error: invalid subsequent chunk header byte. index=1 byte=254"
+    );
+    assert_eq!(
+        format!("{}", DecodingError::InvalidSubsequentSizeHeader(254 * 255)),
+        "HCOBS decoding error: invalid subsequent size. size=64770"
+    );
+    assert_eq!(
+        format!("{}", DecodingError::CutShort),
+        "HCOBS decoding error: decoding terminated mid-chunk"
+    );
+    assert_eq!(
+        format!("{}", DecodingError::MissingImplicitTerminator),
+        "HCOBS decoding error: decoding terminated without implicit stuff sequence terminator"
+    );
+}

--- a/hcobs/src/encoder.rs
+++ b/hcobs/src/encoder.rs
@@ -1,0 +1,380 @@
+use crate::find_stuff_sequence;
+use crate::Parameters;
+use crate::PROD_PARAMS;
+use crate::RADIX;
+use crate::STUFF_SEQUENCE;
+#[cfg(test)]
+use crate::TEST_PARAMS;
+
+use std::num::NonZeroUsize;
+
+use owning_iovec::Backref;
+use owning_iovec::OwningIovec;
+
+#[derive(Debug)]
+pub struct EncoderState {
+    // Initially `max_initial_size`, then `max_subsequent_size` for subsequent
+    // chunks.
+    max_chunk_size: NonZeroUsize,
+    // How many bytes we've accumulated in the chunk so far.  Once this reaches
+    // `max_chunk_size`, we must terminate the chunk.
+    current_chunk_size: usize,
+    // True if we might have stopped encoding in the middle of a stuff sequence,
+    // and must wait for the next byte to know for sure (if it is, we must
+    // terminate the chunk).
+    maybe_mid_stuff: bool,
+    // Backreference to the size header for the current chunk.
+    backref: Backref,
+}
+
+impl Default for EncoderState {
+    fn default() -> Self {
+        EncoderState {
+            max_chunk_size: PROD_PARAMS.max_initial_size,
+            current_chunk_size: 0,
+            maybe_mid_stuff: false,
+            backref: Default::default(),
+        }
+    }
+}
+
+impl EncoderState {
+    pub fn new(iovec: &mut OwningIovec<'_>, params: Parameters) -> Self {
+        EncoderState {
+            max_chunk_size: params.max_initial_size,
+            current_chunk_size: 0,
+            maybe_mid_stuff: false,
+            backref: iovec.register_patch(&[0u8]),
+        }
+    }
+
+    fn new_subsequent(iovec: &mut OwningIovec<'_>, params: Parameters) -> Self {
+        EncoderState {
+            max_chunk_size: params.max_subsequent_size,
+            current_chunk_size: 0,
+            maybe_mid_stuff: false,
+            backref: iovec.register_patch(&[0u8, 0u8]),
+        }
+    }
+
+    pub fn encode_borrow<'slices>(
+        mut self,
+        iovec: &mut OwningIovec<'slices>,
+        params: Parameters,
+        mut input: &'slices [u8],
+    ) -> Self {
+        while !input.is_empty() {
+            // If `maybe_mid_stuff`, we're buffering one byte, because it's
+            // equal to `STUFF_SEQUENCE[0]`.
+            let had_buffered_data = self.maybe_mid_stuff;
+            let consumed;
+
+            (self, consumed) = self.consume_once(iovec, params, input, |this, iovec, prefix| {
+                this.write(iovec, &input[0..prefix]);
+            });
+
+            // Can't consume too much.
+            assert!(consumed <= input.len());
+            // We should usually consume something, but it's possible to not
+            // consume anything if we instead dumped our internal buffered byte.
+            assert!((consumed > 0) | (!self.maybe_mid_stuff & had_buffered_data));
+
+            input = &input[consumed..];
+        }
+
+        self
+    }
+
+    pub fn encode_copy(
+        mut self,
+        iovec: &mut OwningIovec<'_>,
+        params: Parameters,
+        mut input: &[u8],
+    ) -> Self {
+        while !input.is_empty() {
+            // If `maybe_mid_stuff`, we're buffering one byte, because it's
+            // equal to `STUFF_SEQUENCE[0]`.
+            let had_buffered_data = self.maybe_mid_stuff;
+            let consumed;
+
+            (self, consumed) = self.consume_once(iovec, params, input, |this, iovec, prefix| {
+                this.copy(iovec, &input[0..prefix]);
+            });
+
+            // Can't consume too much.
+            assert!(consumed <= input.len());
+            // We should usually consume something, but it's possible to not
+            // consume anything if we instead dumped our internal buffered byte.
+            assert!((consumed > 0) | (!self.maybe_mid_stuff & had_buffered_data));
+
+            input = &input[consumed..];
+        }
+
+        self
+    }
+
+    pub fn terminate(mut self, iovec: &mut OwningIovec<'_>) {
+        if self.maybe_mid_stuff {
+            self.write_partial_stuff_sequence(iovec);
+        }
+
+        assert!(self.current_chunk_size < self.max_chunk_size.get());
+        Self::encode_header(self.current_chunk_size, iovec, self.backref);
+    }
+
+    fn encode_header(chunk_size: usize, iovec: &mut OwningIovec<'_>, backref: Backref) {
+        assert!(chunk_size < RADIX * RADIX);
+
+        let header = [(chunk_size % RADIX) as u8, (chunk_size / RADIX) as u8, 0];
+        let len = backref.len();
+        assert!((1..=2).contains(&len));
+        assert!(header[len] == 0);
+
+        iovec.backfill_or_panic(backref, &header[0..len]);
+    }
+
+    #[inline(never)]
+    fn write<'slices>(&mut self, iovec: &mut OwningIovec<'slices>, payload: &'slices [u8]) {
+        if payload.is_empty() {
+            return;
+        }
+
+        iovec.push(payload);
+        self.current_chunk_size += payload.len();
+        assert!(self.current_chunk_size <= self.max_chunk_size.get());
+    }
+
+    #[inline(never)]
+    fn copy(&mut self, iovec: &mut OwningIovec<'_>, payload: &[u8]) {
+        if payload.is_empty() {
+            return;
+        }
+
+        iovec.push_copy(payload);
+        self.current_chunk_size += payload.len();
+        assert!(self.current_chunk_size <= self.max_chunk_size.get());
+    }
+
+    #[inline(always)]
+    fn write_partial_stuff_sequence(&mut self, iovec: &mut OwningIovec<'_>) {
+        iovec.push_copy(&[STUFF_SEQUENCE[0]]);
+        self.current_chunk_size += 1;
+        assert!(self.current_chunk_size <= self.max_chunk_size.get());
+    }
+
+    fn consume_once<'slices>(
+        mut self,
+        iovec: &mut OwningIovec<'slices>,
+        params: Parameters,
+        mut input: &[u8],
+        // writer writes the `usize` prefix of `input` to the iovec.
+        writer: impl FnOnce(&mut Self, &mut OwningIovec<'slices>, usize),
+    ) -> (Self, usize) {
+        assert!(!input.is_empty());
+        assert!(
+            self.current_chunk_size + (self.maybe_mid_stuff as usize) < self.max_chunk_size.get()
+        );
+
+        // How many bytes we consumed before terminating the chunk
+        let consumed = if self.maybe_mid_stuff & (input[0] == STUFF_SEQUENCE[1]) {
+            // Completed a stuff between two slices sequence, write out the header!
+            1
+        } else {
+            assert!(self.current_chunk_size < self.max_chunk_size.get());
+
+            if self.maybe_mid_stuff {
+                // We buffered the previous slice's last byte. Write it out.
+                self.write_partial_stuff_sequence(iovec);
+                // If this was the last byte, we would have flushed it.
+                assert!(self.current_chunk_size < self.max_chunk_size.get());
+            }
+
+            let remaining = self.max_chunk_size.get() - self.current_chunk_size;
+            input = &input[..input.len().min(remaining)];
+
+            // remaining > 0 and input is initially non-empty.
+            assert!(!input.is_empty());
+
+            // See if we found the end of a chunk.
+            let (num_to_write, consumed) = if let Some(index) = find_stuff_sequence(input) {
+                // We found a stuff sequence before the mandatory end of chunk.
+                (index, index + STUFF_SEQUENCE.len())
+            } else if input.len() == remaining {
+                // We got to the mandatory end of the chunk.
+                (remaining, remaining)
+            } else {
+                // we're definitely not done with the chunk sequence.
+                let ret = input.len();
+
+                // If the slice's last byte matches the first of the stuff sequence,
+                // we can't write it out just yet.
+                self.maybe_mid_stuff = input[input.len() - 1] == STUFF_SEQUENCE[0];
+                let to_copy = if self.maybe_mid_stuff { ret - 1 } else { ret };
+
+                writer(&mut self, iovec, to_copy);
+
+                assert!(
+                    self.current_chunk_size + (self.maybe_mid_stuff as usize)
+                        < self.max_chunk_size.get()
+                );
+                return (self, ret);
+            };
+
+            writer(&mut self, iovec, num_to_write);
+            consumed
+        };
+
+        Self::encode_header(self.current_chunk_size, iovec, self.backref);
+        (Self::new_subsequent(iovec, params), consumed)
+    }
+}
+
+#[cfg(test)]
+fn encode_with_test_params(bytes: &[u8]) -> Vec<u8> {
+    let mut iovec = OwningIovec::new();
+    let mut encoder = EncoderState::new(&mut iovec, TEST_PARAMS);
+
+    encoder = encoder.encode_borrow(&mut iovec, TEST_PARAMS, bytes);
+    encoder.terminate(&mut iovec);
+
+    let ret = iovec.flatten().expect("no backpatch left");
+
+    // Redundantly encode with copy and check it's the same result
+    {
+        let mut iovec = OwningIovec::new();
+        let mut encoder = EncoderState::new(&mut iovec, TEST_PARAMS);
+
+        encoder = encoder.encode_copy(&mut iovec, TEST_PARAMS, bytes);
+        encoder.terminate(&mut iovec);
+
+        assert_eq!(&iovec.flatten().expect("no backpatch left"), &ret);
+    }
+
+    assert_eq!(super::find_stuff_sequence(&ret), None);
+
+    ret
+}
+
+// Test some expected input/output pairs
+#[test]
+fn test_simple_miri() {
+    assert_eq!(encode_with_test_params(b""), b"\x00");
+    assert_eq!(encode_with_test_params(b"1"), b"\x011");
+    assert_eq!(encode_with_test_params(b"12"), b"\x0212");
+    assert_eq!(encode_with_test_params(b"123"), b"\x03123\x00\x00");
+    assert_eq!(encode_with_test_params(b"1234567"), b"\x03123\x04\x004567");
+    assert_eq!(
+        encode_with_test_params(b"12345678"),
+        b"\x03123\x05\x0045678\x00\x00"
+    );
+    assert_eq!(
+        encode_with_test_params(b"123456789"),
+        b"\x03123\x05\x0045678\x01\x009"
+    );
+    assert_eq!(encode_with_test_params(b"\xFE\xFD"), b"\x00\x00\x00");
+    assert_eq!(encode_with_test_params(b"1\xFE\xFD"), b"\x011\x00\x00");
+    assert_eq!(
+        encode_with_test_params(b"12\xFE\xFD"),
+        b"\x0312\xFE\x01\x00\xFD"
+    );
+    assert_eq!(
+        encode_with_test_params(b"123\xFE\xFD"),
+        b"\x03123\x00\x00\x00\x00"
+    );
+    assert_eq!(
+        encode_with_test_params(b"1234\xFE\xFD\xFE"),
+        b"\x03123\x01\x004\x01\x00\xFE"
+    );
+    assert_eq!(
+        encode_with_test_params(b"1234\xFE\xFE\xFD"),
+        b"\x03123\x02\x004\xFE\x00\x00"
+    );
+    assert_eq!(
+        encode_with_test_params(b"1234\xFE\xFE\xFE"),
+        b"\x03123\x04\x004\xFE\xFE\xFE"
+    );
+    assert_eq!(
+        encode_with_test_params(b"1234\xFD\xFD\xFD"),
+        b"\x03123\x04\x004\xFD\xFD\xFD"
+    );
+}
+
+// Split a bunch of test vectors in different places, make sure the
+// the result is the same.
+//
+// The idea is that the encoding is deterministic function of the
+// current state and the input slice, and that terminating the
+// encoding captures the current state pretty well.
+#[cfg(test)]
+fn compare_encode_with_test_params(contiguous: &[u8], split: &[&[u8]]) {
+    let contiguous_encoded = encode_with_test_params(contiguous);
+
+    let mut iovec = OwningIovec::new();
+    let mut encoder = EncoderState::new(&mut iovec, TEST_PARAMS);
+
+    for subslice in split.iter().copied() {
+        encoder = encoder.encode_copy(&mut iovec, TEST_PARAMS, subslice);
+    }
+
+    encoder.terminate(&mut iovec);
+
+    let split_encoded = iovec.flatten().expect("no backpatch left");
+
+    // Same thing with borrow and copy.
+    for should_copy in [[false, false], [true, false], [false, true]] {
+        // we already did copy everything
+        let mut iovec = OwningIovec::new();
+        let mut encoder = EncoderState::new(&mut iovec, TEST_PARAMS);
+
+        for (idx, subslice) in split.iter().copied().enumerate() {
+            if should_copy[idx % 2] {
+                encoder = encoder.encode_borrow(&mut iovec, TEST_PARAMS, subslice);
+            } else {
+                encoder = encoder.encode_copy(&mut iovec, TEST_PARAMS, subslice);
+            }
+        }
+
+        encoder.terminate(&mut iovec);
+
+        assert_eq!(
+            &split_encoded,
+            &iovec.flatten().unwrap() // ,
+                                      // "should_copy={:?}",
+                                      // should_copy
+        );
+    }
+
+    assert_eq!(
+        contiguous_encoded,
+        split_encoded // ,
+                      // "contiguous={:?}\nsplit={:?}\n => {:?}\n => {:?}",
+                      // contiguous, split, contiguous_encoded, split_encoded
+    );
+}
+
+#[test]
+fn test_split_slow() {
+    let patterns = &[
+        b"123456789abcdef",
+        b"12345678\xFE\xFD\xFEabcd",
+        b"12345678\xFE\xFE\xFEabcd",
+        b"12345678\xFD\xFD\xFDabcd",
+        b"12345678\xFD\xFE\xFDabcd",
+    ];
+
+    #[cfg(miri)]
+    let patterns = &patterns[..2];
+
+    for pattern in patterns {
+        for start in 0..pattern.len() {
+            for end in (start + 1)..=pattern.len() {
+                for mid in start..=end {
+                    compare_encode_with_test_params(
+                        &pattern[start..end],
+                        &[&pattern[start..mid], &pattern[mid..end]],
+                    );
+                }
+            }
+        }
+    }
+}

--- a/hcobs/src/lib.rs
+++ b/hcobs/src/lib.rs
@@ -1,0 +1,736 @@
+//! The `hcobs` crate implements the hybrid consistent-overhead byte/word
+//! stuffing scheme of <https://pvk.ca/Blog/2021/01/11/stuff-your-logs/>,
+//! with an incremental interface (via [`OwningIovec`]).
+//!
+//! Writers should only need the [`Encoder`].
+//!
+//! When the HCOBS-encoded bytes are embedded in a higher-level
+//! format, the [`Decoder`] is useful to decode one record at a time.
+//!
+//! However, HCOBS makes a lot of sense as the outermost framing; the
+//! [`StreamReader`] is ideal for that use-case (the write side can
+//! simply use an [`Encoder`]).  More complicated formats may require
+//! the direct use of a [`StreamChunker`], to find [`STUFF_SEQUENCE`]-
+//! delimited subsequences and pass (part of) the subsequences to a
+//! [`Decoder`].
+mod decoder;
+mod encoder;
+mod stream_reader;
+
+use std::io::Read;
+use std::num::NonZeroUsize;
+
+use decoder::DecoderState;
+use encoder::EncoderState;
+use owning_iovec::AnchoredSlice;
+use owning_iovec::ConsumingIovec;
+use owning_iovec::OwningIovec;
+
+pub use decoder::DecodingError;
+
+pub use stream_reader::Chunk;
+pub use stream_reader::StreamAction;
+pub use stream_reader::StreamChunker;
+pub use stream_reader::StreamReader;
+pub use stream_reader::DEFAULT_BLOCK_SIZE;
+
+/// The encoding radix for size headers in the hybrid byte stuffing scheme (253).
+pub const RADIX: usize = 0xfd;
+#[allow(clippy::assertions_on_constants)]
+const _: () = assert!(RADIX == 253);
+
+/// The forbidden (stuff) sentinel sequence that is removed by encoding
+/// and restored by decoding (`[0xFE, 0xFD]`).
+pub const STUFF_SEQUENCE: [u8; 2] = [0xfe, 0xfd];
+
+#[derive(Clone, Copy)]
+struct Parameters {
+    max_initial_size: NonZeroUsize,
+    max_subsequent_size: NonZeroUsize,
+}
+
+const PROD_PARAMS: Parameters = Parameters {
+    max_initial_size: unsafe { NonZeroUsize::new_unchecked(RADIX - 1) },
+    max_subsequent_size: unsafe { NonZeroUsize::new_unchecked((RADIX * RADIX) - 1) },
+};
+
+#[cfg(test)]
+const TEST_PARAMS: Parameters = Parameters {
+    max_initial_size: unsafe { NonZeroUsize::new_unchecked(3) },
+    max_subsequent_size: unsafe { NonZeroUsize::new_unchecked(5) },
+};
+
+/// Returns the index (for the first byte) for the first occurrence of
+/// [`STUFF_SEQUENCE`] in the input `bytes`, or `None` if the stuff
+/// sequence can't be found.
+#[must_use]
+#[inline(never)] // Keep out of line for profiling
+pub fn find_stuff_sequence(bytes: &[u8]) -> Option<usize> {
+    for (idx, window) in bytes.windows(2).enumerate() {
+        if window == STUFF_SEQUENCE {
+            return Some(idx);
+        }
+    }
+
+    None
+}
+
+/// Byte stuffs arbitrary inputs incrementally; slices that live
+/// as long the lifetime argument may be borrowed for encoding.
+///
+/// The encoder has a bounded amount of state, including the
+/// [`OwningIovec`], which also hangs on to a bounded amount of data
+/// that's not yet ready to be consumed: the HCOBS encoding scheme
+/// only needs to buffer at most 64 KB of data.
+///
+/// Of course, the [`OwningIovec`] will keep growing until the encoded
+/// bytes are consumed from it.
+#[derive(Debug)]
+pub struct Encoder<'this> {
+    state: EncoderState,
+    iovec: OwningIovec<'this>,
+}
+
+impl<'this> Default for Encoder<'this> {
+    #[inline(always)]
+    fn default() -> Self {
+        Encoder::new()
+    }
+}
+
+impl<'this> owning_iovec::ZeroCopySink<'this> for Encoder<'this> {
+    fn append_copy(&mut self, bytes: &[u8]) {
+        self.encode_copy(bytes)
+    }
+
+    fn append_borrow(&mut self, bytes: &'this [u8]) {
+        self.encode(bytes)
+    }
+}
+
+impl<'this> Encoder<'this> {
+    /// Returns a new encoder with a fresh [`OwningIovec`].
+    #[must_use]
+    pub fn new() -> Self {
+        Encoder::new_from_iovec(OwningIovec::new())
+    }
+
+    /// Returns a new encoder with a pre-existing [`OwningIovec`].
+    ///
+    /// Encoded bytes are appended after `iovec`'s current contents.
+    #[must_use]
+    pub fn new_from_iovec(mut iovec: OwningIovec<'this>) -> Self {
+        Encoder {
+            state: EncoderState::new(&mut iovec, PROD_PARAMS),
+            iovec,
+        }
+    }
+
+    /// Returns a consuming wrapper for the underlying [`OwningIovec`]
+    ///
+    /// Useful to consume incrementally from the output.
+    #[must_use]
+    #[inline(always)]
+    pub fn consumer(&mut self) -> ConsumingIovec<'_> {
+        self.iovec.consumer()
+    }
+
+    /// Appends `data` to the bytes to encode.
+    ///
+    /// This method tries to avoid copying large `data`.
+    pub fn encode(&mut self, data: &'this [u8]) {
+        let mut state = Default::default();
+        std::mem::swap(&mut state, &mut self.state);
+        self.state = state.encode_borrow(&mut self.iovec, PROD_PARAMS, data);
+    }
+
+    /// Appends `data` to the bytes to encode.
+    pub fn encode_copy(&mut self, data: &[u8]) {
+        let mut state = Default::default();
+        std::mem::swap(&mut state, &mut self.state);
+        self.state = state.encode_copy(&mut self.iovec, PROD_PARAMS, data);
+    }
+
+    /// Appends the bytes in `data` to the bytes to encode.
+    pub fn encode_anchored(&mut self, data: AnchoredSlice) {
+        let (_, slice, anchor) = unsafe { data.components() };
+
+        if slice.is_empty() {
+            // This is a speed optimisation, but also avoids
+            // accumulating useless anchors.
+            return;
+        }
+
+        self.encode(slice);
+        self.iovec.push_anchor(anchor);
+    }
+
+    /// Flushes any pending encoding bytes and returns the underlying
+    /// [`OwningIovec`].
+    #[must_use]
+    pub fn finish(mut self) -> OwningIovec<'this> {
+        self.state.terminate(&mut self.iovec);
+        self.iovec
+    }
+
+    /// Reads up to `count` bytes from `reader` with up to `attempts` calls, and
+    /// ensures the result is allocated in the underlying [`owning_iovec::ByteArena`].
+    ///
+    /// The method retries up to `attempts` times to paper over
+    /// [`ErrorKind::Interrupted`] and short reads.
+    ///
+    /// EOF (0-sized reads) and non-[`ErrorKind::Interrupted`] error always stop the
+    /// the retries.
+    ///
+    /// If the retry loop managed to read at least one byte, that's considered a success
+    /// and returned to the caller.  Otherwise, returns the result of the last attempt
+    /// (an error or an empty slice on EOF).
+    ///
+    /// [`ErrorKind::Interrupted`]: [`std::io::ErrorKind::Interrupted`]
+    #[inline(always)]
+    pub fn read_n(
+        &mut self,
+        reader: impl Read,
+        count: usize,
+        attempts: NonZeroUsize,
+    ) -> std::io::Result<AnchoredSlice> {
+        let anchored_slice = self.iovec.arena().read_n(reader, count, attempts)?;
+        assert!(anchored_slice.slice().len() <= count);
+        Ok(anchored_slice)
+    }
+
+    /// Convenience wrapper around [`Self::read_n`] and [`Self::encode_anchored`].
+    ///
+    /// Reads up to `count` bytes from `reader` with up to `attempts` calls, then
+    /// encodes the bytes read.
+    ///
+    /// On success. returns the number of bytes read from `reader`.  Failure can
+    /// only happen during reading.
+    pub fn encode_read(
+        &mut self,
+        reader: impl Read,
+        count: usize,
+        attempts: NonZeroUsize,
+    ) -> std::io::Result<usize> {
+        let anchored_slice = self.read_n(reader, count, attempts)?;
+        let ret = anchored_slice.slice().len();
+
+        self.encode_anchored(anchored_slice);
+        Ok(ret)
+    }
+}
+
+/// Attempts to decode byte-stuffed data incrementally; slices that live
+/// as long the lifetime argument may be borrowed for decoding.
+///
+/// The encoder itself has a bounded amount of state, including the
+/// [`OwningIovec`].  Of course, the [`OwningIovec`] will keep growing
+/// until the encoded bytes are consumed from it.
+#[derive(Debug)]
+pub struct Decoder<'this> {
+    state: DecoderState,
+    iovec: OwningIovec<'this>,
+}
+
+impl<'this> Default for Decoder<'this> {
+    #[inline(always)]
+    fn default() -> Self {
+        Decoder::new()
+    }
+}
+
+impl<'this> Decoder<'this> {
+    /// Returns a new decoder with a fresh [`OwningIovec`].
+    #[must_use]
+    pub fn new() -> Self {
+        Decoder::new_from_iovec(OwningIovec::new())
+    }
+
+    /// Returns a new decoder with a pre-existing [`OwningIovec`].
+    ///
+    /// Decoded bytes are appended after `iovec`'s current contents.
+    #[must_use]
+    pub fn new_from_iovec(iovec: OwningIovec<'this>) -> Self {
+        Decoder {
+            state: DecoderState::new(),
+            iovec,
+        }
+    }
+
+    /// Returns a consumer for the underlying [`OwningIovec`].
+    ///
+    /// Useful to consume incrementally from the output.
+    #[must_use]
+    #[inline(always)]
+    pub fn consumer(&mut self) -> ConsumingIovec<'_> {
+        self.iovec.consumer()
+    }
+
+    /// Returns the internal [`OwningIovec`] with the remainder
+    /// of the bytes decoded so far.
+    #[must_use]
+    #[inline(always)]
+    pub fn take_iovec(self) -> OwningIovec<'this> {
+        self.iovec
+    }
+
+    /// Appends `data` to the bytes to decode.
+    ///
+    /// This methods tries to avoid copying large `data`.
+    pub fn decode(&mut self, data: &'this [u8]) -> Result<(), DecodingError> {
+        let mut state = Default::default();
+        std::mem::swap(&mut state, &mut self.state);
+        self.state = state.decode_borrow(&mut self.iovec, PROD_PARAMS, data)?;
+        Ok(())
+    }
+
+    /// Appends `data` to the bytes to decode.
+    pub fn decode_copy(&mut self, data: &[u8]) -> Result<(), DecodingError> {
+        let mut state = Default::default();
+        std::mem::swap(&mut state, &mut self.state);
+        self.state = state.decode_copy(&mut self.iovec, PROD_PARAMS, data)?;
+        Ok(())
+    }
+
+    /// Appends the contents of `data` to the bytes to decode.
+    pub fn decode_anchored(&mut self, data: AnchoredSlice) -> Result<(), DecodingError> {
+        let (_, slice, anchor) = unsafe { data.components() };
+
+        if slice.is_empty() {
+            // This is a speed optimisation, but also avoids
+            // accumulating useless anchors.
+            return Ok(());
+        }
+
+        let ret = self.decode(slice);
+        self.iovec.push_anchor(anchor);
+        ret
+    }
+
+    /// Returns the underlying `OwningIovec`, if the input is complete and valid.
+    pub fn finish(self) -> Result<OwningIovec<'this>, DecodingError> {
+        self.state.terminate()?;
+        Ok(self.iovec)
+    }
+
+    /// Reads up to `count` bytes from `reader` with up to `attempts` calls, and
+    /// ensures the result is allocated in the underlying [`owning_iovec::ByteArena`].
+    ///
+    /// The method retries up to `attempts` times to paper over
+    /// [`ErrorKind::Interrupted`] and short reads.
+    ///
+    /// EOF (0-sized reads) and non-[`ErrorKind::Interrupted`] error always stop the
+    /// the retries.
+    ///
+    /// If the retry loop managed to read at least one byte, that's considered a success
+    /// and returned to the caller.  Otherwise, returns the result of the last attempt
+    /// (an error or an empty slice on EOF).
+    ///
+    /// [`ErrorKind::Interrupted`]: [`std::io::ErrorKind::Interrupted`]
+    #[inline(always)]
+    pub fn read_n(
+        &mut self,
+        reader: impl Read,
+        count: usize,
+        attempts: NonZeroUsize,
+    ) -> std::io::Result<AnchoredSlice> {
+        let anchored_slice = self.iovec.arena().read_n(reader, count, attempts)?;
+        assert!(anchored_slice.slice().len() <= count);
+        Ok(anchored_slice)
+    }
+
+    /// Convenience wrapper around [`Self::read_n`] and [`Self::decode_anchored`].
+    ///
+    /// Reads up to `count` bytes from `reader` with up to `attempts` calls, then
+    /// attempts to decode the bytes read.
+    ///
+    /// On success. returns the number of bytes read from `reader`.  Failure could
+    /// happen during reading or decoding (with `ErrorKind::other` for the latter).
+    pub fn decode_read(
+        &mut self,
+        reader: impl Read,
+        count: usize,
+        attempts: NonZeroUsize,
+    ) -> std::io::Result<usize> {
+        let anchored_slice = self.read_n(reader, count, attempts)?;
+
+        let len = anchored_slice.slice().len();
+        match self.decode_anchored(anchored_slice) {
+            Ok(()) => Ok(len),
+            Err(e) => Err(std::io::Error::other(e)),
+        }
+    }
+}
+
+#[cfg(test)]
+struct BadReader {
+    count: usize, // first invocation is successful.
+}
+
+#[cfg(test)]
+impl Read for BadReader {
+    fn read(&mut self, dst: &mut [u8]) -> std::io::Result<usize> {
+        self.count += 1;
+        match self.count {
+            1 => {
+                let mut reader = &b"7"[..];
+                reader.read(dst)
+            }
+            2 => Err(std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                "interrupted",
+            )),
+            3 => {
+                let mut reader = &b"89"[..];
+                reader.read(dst)
+            }
+            5 => {
+                let mut reader = &b""[..];
+                reader.read(dst)
+            }
+            _ => Err(std::io::Error::other("bad read")),
+        }
+    }
+}
+
+// Smoke test the public interface.
+#[test]
+fn smoke_test_miri() {
+    let mut encoder: Encoder<'_> = Default::default();
+
+    encoder.consumer().arena().ensure_capacity(10);
+    encoder.encode(b"123");
+    encoder.encode_copy(b"456");
+    // Empty anchored slice -> no-op.
+    encoder.encode_anchored(Default::default());
+    assert!(encoder
+        .encode_read(BadReader { count: 10 }, 3, NonZeroUsize::new(1).unwrap())
+        .is_err()); // Bad read should no-op
+    assert_eq!(
+        encoder
+            .encode_read(BadReader { count: 10 }, 0, NonZeroUsize::new(1).unwrap())
+            .unwrap(),
+        0
+    ); // 0-sized reads succeed
+    assert_eq!(
+        encoder
+            .encode_read(BadReader { count: 4 }, 3, NonZeroUsize::new(1).unwrap())
+            .unwrap(),
+        0
+    ); // EOF read succeed
+    assert!(encoder
+        .encode_read(BadReader { count: 1 }, 3, NonZeroUsize::new(1).unwrap())
+        .is_err()); // EINTR fails
+    assert_eq!(
+        encoder
+            .encode_read(BadReader { count: 0 }, 4, NonZeroUsize::new(5).unwrap())
+            .expect("read must succeed"),
+        3
+    ); // handle short reads
+
+    assert_eq!(
+        encoder
+            .encode_read(BadReader { count: 0 }, 3, NonZeroUsize::new(5).unwrap())
+            .expect("read must succeed"),
+        3
+    ); // exact reads also work
+
+    let iovec = encoder.finish();
+    assert_eq!(
+        iovec.flatten().expect("no backpatch left"),
+        b"\x0c123456789789"
+    );
+
+    // decode
+    {
+        let mut decoder: Decoder<'_> = Default::default();
+        for slice in iovec.into_iter() {
+            decoder.decode(slice).expect("success");
+        }
+
+        // Can peek
+        assert_eq!(
+            decoder.consumer().flatten().expect("no backpatch left"),
+            b"123456789789"
+        );
+
+        // Termination succeeds
+        let output = decoder.finish().expect("success");
+        assert_eq!(
+            output.flatten().expect("no backpatch left"),
+            b"123456789789"
+        );
+    }
+
+    // decode copy
+    {
+        let mut decoder: Decoder<'_> = Default::default();
+        for slice in iovec.into_iter() {
+            decoder.decode_copy(slice).expect("success");
+        }
+
+        assert_eq!(
+            decoder.consumer().flatten().expect("no backpatch left"),
+            b"123456789789"
+        );
+
+        let output = decoder.finish().expect("success");
+        assert_eq!(
+            output.flatten().expect("no backpatch left"),
+            b"123456789789"
+        );
+    }
+
+    // decode read
+    {
+        let mut decoder: Decoder<'_> = Default::default();
+
+        // Bad read should no-op
+        assert!(decoder
+            .decode_read(BadReader { count: 10 }, 3, NonZeroUsize::new(1).unwrap())
+            .is_err());
+
+        for slice in iovec.into_iter() {
+            let slice: &[u8] = slice;
+            decoder
+                .decode_read(slice, slice.len(), NonZeroUsize::new(1).unwrap())
+                .expect("success");
+        }
+
+        // Empty slice should no-op.
+        decoder
+            .decode_anchored(Default::default())
+            .expect("should work");
+
+        assert_eq!(
+            decoder.consumer().flatten().expect("no backpatch left"),
+            b"123456789789"
+        );
+
+        let output = decoder.finish().expect("success");
+        assert_eq!(
+            output.flatten().expect("no backpatch left"),
+            b"123456789789"
+        );
+    }
+}
+
+#[test]
+fn test_zero_copy_sink_miri() {
+    fn encode<'a>(mut dst: impl owning_iovec::ZeroCopySink<'a>) {
+        dst.append_copy(b"123");
+        dst.append_borrow(b"abc");
+    }
+
+    let mut baseline_encoder: Encoder<'_> = Default::default();
+
+    baseline_encoder.encode_copy(b"123abc");
+
+    let mut zc_encoder: Encoder<'_> = Default::default();
+    encode(&mut zc_encoder);
+
+    let baseline = baseline_encoder.finish().flatten().unwrap();
+    let zc = zc_encoder.finish().flatten().unwrap();
+
+    assert_eq!(baseline, zc);
+}
+
+#[test]
+fn test_decoder_take() {
+    let mut iovec = OwningIovec::new();
+
+    iovec.push_borrowed(b"12");
+
+    let mut decoder = Decoder::new_from_iovec(iovec);
+    decoder.decode(b"\x013").expect("is valid");
+
+    let iovec = decoder.take_iovec();
+    assert_eq!(iovec.flatten().unwrap(), b"123");
+}
+
+// make sure we can consume incrementally with the prod interface.
+#[test]
+fn test_prod_peek_miri() {
+    let mut encoder: Encoder<'_> = Default::default();
+
+    // The initial cache is 4KB, write that much.
+    for _ in 0..1024 {
+        encoder.encode(b"\x00\x00\x00\x00");
+    }
+
+    // Force the chunk to end.
+    encoder.encode(b"\xFE\xFD");
+
+    let header: &[u8] = b"\xfc";
+    let zeros = vec![0u8; 4000];
+    let second_header: &[u8] = b"\x31\x0f";
+    // 252 zeros, then 4096 - 252 = 3844 zeros.
+    let expected = [header, &zeros[..252], second_header, &zeros[..3844]].concat();
+
+    assert_eq!(encoder.consumer().stable_prefix().len(), 1);
+
+    assert_eq!(
+        &encoder
+            .consumer()
+            .stable_prefix()
+            .iter()
+            .flat_map(|x| -> &[u8] { x })
+            .copied()
+            .collect::<Vec<u8>>(),
+        // Only 4095 because the last 4-byte write goes directly to the
+        // next arena chunk instead of spltting.
+        &expected[0..4095]
+    );
+
+    assert_eq!(encoder.consumer().consume(1), 1);
+
+    let iovec = encoder.finish();
+    assert_eq!(
+        iovec.flatten().expect("no backpatch left"),
+        [
+            0, 0, 0, 0, // final 4-byte write
+            0, 0
+        ] // terminator
+    );
+}
+
+// Exercise error handling in decoding.
+#[test]
+fn test_prod_decode_bad_miri() {
+    {
+        let mut decoder: Decoder<'_> = Default::default();
+
+        // Bad data.
+        assert!(decoder.decode(b"\xff").is_err());
+    }
+
+    {
+        let mut decoder: Decoder<'_> = Default::default();
+
+        // Same, with decode_copy
+        assert!(decoder.decode_copy(b"\xff").is_err());
+    }
+
+    {
+        let mut decoder: Decoder<'_> = Default::default();
+
+        // Truncated chunk
+        decoder.decode(b"\xfc").expect("ok");
+        decoder.decode_copy(&vec![0u8; 253]).expect("ok");
+
+        // Missing the next chunk.
+        assert!(decoder.finish().is_err());
+    }
+}
+
+#[cfg(test)]
+fn prod_encode_streaming(repeat: usize) {
+    assert_eq!(owning_iovec::ByteArena::num_live_chunks(), 0);
+    assert_eq!(owning_iovec::ByteArena::num_live_bytes(), 0);
+
+    let mut encoder: Encoder<'_> = Default::default();
+    let payload = [1u8; 1000];
+
+    for _ in 0..repeat {
+        encoder.encode_copy(&payload);
+        let consumer = encoder.consumer();
+        let prefix = consumer.stable_prefix();
+        if !prefix.is_empty() {
+            let len = prefix.len();
+            assert_eq!(encoder.consumer().consume(len), len);
+        }
+    }
+
+    assert!(owning_iovec::ByteArena::num_live_chunks() <= 2);
+    assert!(owning_iovec::ByteArena::num_live_bytes() <= 2 * 1024 * 1024);
+
+    std::mem::drop(encoder);
+
+    assert_eq!(owning_iovec::ByteArena::num_live_chunks(), 0);
+    assert_eq!(owning_iovec::ByteArena::num_live_bytes(), 0);
+}
+
+#[cfg(miri)]
+#[test]
+fn prod_encode_streaming_slow() {
+    prod_encode_streaming(400);
+}
+
+#[cfg(test)]
+fn prod_decode_streaming(repeat: usize) {
+    assert_eq!(owning_iovec::ByteArena::num_live_chunks(), 0);
+    assert_eq!(owning_iovec::ByteArena::num_live_bytes(), 0);
+
+    let mut decoded_size = 0usize;
+    let payload = [1u8; 1000];
+    let mut encoder: Encoder<'_> = Default::default();
+
+    let mut decoder: Decoder<'_> = Default::default();
+
+    for _ in 0..repeat {
+        encoder.encode(&payload);
+        let mut consumer = encoder.consumer();
+        let prefix = consumer.stable_prefix();
+        for slice in prefix {
+            decoder.decode_copy(slice).expect("ok");
+        }
+
+        let len = prefix.len();
+        assert_eq!(consumer.consume(prefix.len()), len);
+
+        let mut consumer = decoder.consumer();
+        let prefix = consumer.stable_prefix();
+        for slice in prefix {
+            let slice: &[u8] = slice;
+            decoded_size += slice.len();
+            for byte in slice {
+                assert_eq!(*byte, 1u8);
+            }
+        }
+
+        let len = prefix.len();
+        assert_eq!(consumer.consume(prefix.len()), len);
+    }
+
+    assert!(owning_iovec::ByteArena::num_live_chunks() <= 3);
+    assert!(owning_iovec::ByteArena::num_live_bytes() <= 3 * 1024 * 1024);
+
+    let tail = encoder.finish().flatten().expect("no backpatch left");
+    decoder.decode_copy(&tail).expect("valid");
+
+    assert!(owning_iovec::ByteArena::num_live_chunks() <= 2);
+    assert!(owning_iovec::ByteArena::num_live_bytes() <= 2 * 1024 * 1024);
+
+    let decoded_tail = decoder.finish().unwrap().flatten().unwrap();
+    decoded_size += decoded_tail.len();
+    for byte in decoded_tail {
+        assert_eq!(byte, 1u8);
+    }
+
+    assert_eq!(decoded_size, repeat * payload.len());
+
+    assert_eq!(owning_iovec::ByteArena::num_live_chunks(), 0);
+    assert_eq!(owning_iovec::ByteArena::num_live_bytes(), 0);
+}
+
+#[cfg(miri)]
+#[test]
+fn test_prod_decode_streaming_slow() {
+    prod_decode_streaming(400);
+}
+
+#[cfg(all(test, not(miri)))]
+use rusty_fork::rusty_fork_test;
+
+#[cfg(all(test, not(miri)))]
+rusty_fork_test! {
+    #[test]
+    fn test_prod_encode_streaming_fork() {
+        prod_encode_streaming(10000);
+    }
+
+    #[test]
+    fn test_prod_decode_streaming_fork() {
+        prod_decode_streaming(10000);
+    }
+}

--- a/hcobs/src/stream_reader.rs
+++ b/hcobs/src/stream_reader.rs
@@ -1,0 +1,590 @@
+//! The `stream_reader` module wraps the low-level [`crate::Decoder`]
+//! to read [`STUFF_SEQUENCE`]-delimited HCOBS-encoded records on the
+//! fly from a stream of bytes.
+use std::io::Result;
+use std::num::NonZeroUsize;
+use std::ops::Range;
+
+use super::Decoder;
+use super::STUFF_SEQUENCE;
+use owning_iovec::AnchoredSlice;
+use owning_iovec::ByteArena;
+use owning_iovec::ConsumingIovec;
+use owning_iovec::OwningIovec;
+
+/// Default IO block size (512 KB).
+pub const DEFAULT_BLOCK_SIZE: usize = 512 * 1024;
+
+#[cfg(test)]
+const TEST_BLOCK_SIZE: Option<usize> = Some(3);
+
+/// A [`StreamReader`] buffers reads from [`std::io::Read`]s and
+/// yields the decoded contents of valid HCOBS-encoded records,
+/// assuming [`STUFF_SEQUENCE`] separators.
+#[derive(Clone, Debug, Default)]
+pub struct StreamReader {
+    iovec: OwningIovec<'static>,
+    chunker: StreamChunker,
+    // Offset of the (first byte of the) last STUFF_SEQUENCE sentinel in `chunker`.
+    last_sentinel_offset: u64,
+}
+
+/// The [`StreamReader`] periodically invokes a function to determine
+/// what to do with the current HCOBS-encoded record.  This enum describes
+/// the potential actions.
+#[must_use]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum StreamAction {
+    /// Keep decoding the record
+    KeepGoing,
+    /// Skip to the next record
+    SkipRecord,
+    /// Stop with EOF right away
+    Stop,
+}
+
+/// The [`StreamChunker`] reads a stream of bytes from a
+/// [`std::io::Read`] and yields a sequence of [`Chunk`]s that fully
+/// describe the input stream (i.e., the [`StreamChunker`] segments
+/// the input stream into a stream of [`Chunk`]s).
+#[derive(Clone, Debug, Default)]
+pub struct StreamChunker {
+    buf: AnchoredSlice,
+    offset: u64,
+}
+
+/// A [`Chunk`] describes a subsequence of an input stream.
+#[derive(Clone, Debug)]
+pub enum Chunk {
+    /// A [`STUFF_SEQUENCE`] sentinel that ends at the `u64` byte
+    /// offset in the input stream.
+    Sentinel(u64),
+    /// End of stream.
+    Eof,
+    /// A slice of bytes that ends at the `u64` byte offset in the
+    /// input stream.  The slice does not contain a [`STUFF_SEQUENCE`]
+    /// nor will two adjacent `Data` chunks split a [`STUFF_SEQUENCE`]
+    /// between their first and last bytes.
+    Data((u64, AnchoredSlice)),
+}
+
+impl StreamChunker {
+    /// Pumps the nect segment from the input stream.
+    ///
+    /// When the [`StreamChunker`] needs to read more data,
+    /// it uses the `reader`, and attempts to read blocks of
+    /// `io_block_size` bytes.
+    pub fn pump(
+        &mut self,
+        arena: &mut ByteArena,
+        mut reader: impl std::io::Read,
+        io_block_size: usize,
+    ) -> Result<Chunk> {
+        use std::io::Read;
+        // Can't do 0-byte I/O
+        let io_block_size = io_block_size.max(1);
+        while self.buf.slice().len() < 2 {
+            let buf = self.buf.take();
+
+            let initial_length = buf.slice().len();
+            let mut slice = buf.slice();
+            let concat = (&mut slice).chain(&mut reader);
+
+            let buf = arena.read_n(concat, io_block_size, NonZeroUsize::MAX)?;
+            if buf.slice().len() == initial_length {
+                // No progress, must be Eof.
+                if buf.slice().is_empty() {
+                    return Ok(Chunk::Eof);
+                } else {
+                    self.offset += buf.slice().len() as u64;
+                    return Ok(Chunk::Data((self.offset, buf)));
+                }
+            }
+
+            self.buf = buf;
+        }
+
+        assert!(self.buf.slice().len() >= 2);
+
+        if self.buf.slice()[0..2] == STUFF_SEQUENCE {
+            self.offset += 2;
+            self.buf.skip_prefix(2);
+            return Ok(Chunk::Sentinel(self.offset));
+        }
+
+        let split_pos = if let Some(idx) = super::find_stuff_sequence(self.buf.slice()) {
+            // Split at the stuff sequence if we have one.
+            idx
+        } else if *self.buf.slice().last().unwrap() == STUFF_SEQUENCE[0] {
+            // Split just before the last byte if it could be part of a stuff sequence
+            self.buf.slice().len() - 1
+        } else {
+            // otherwise, take the whole slice.
+            self.buf.slice().len()
+        };
+
+        // We already checked for that case.
+        assert_ne!(split_pos, 0);
+
+        let prefix;
+        (prefix, self.buf) = self.buf.take().split_at(split_pos);
+
+        self.offset += prefix.slice().len() as u64;
+        Ok(Chunk::Data((self.offset, prefix)))
+    }
+}
+
+impl StreamReader {
+    /// Returns a fresh default-constructed [`StreamReader`]
+    #[must_use]
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Returns a judge function for HCOBS-encoded records.
+    ///
+    /// Records whose size exceeds `max_record_size` are skipped, and
+    /// decoding stops when we see [`STUFF_SEQUENCE`] delimiter for a new
+    /// record that would start at or after `limit_offset` in the encoded
+    /// bytes.
+    pub fn chunk_judge(
+        max_record_size: usize,
+        limit_offset: Option<u64>,
+    ) -> impl Fn(Range<u64>, ConsumingIovec<'_>) -> StreamAction {
+        let limit_offset = limit_offset.unwrap_or(u64::MAX);
+
+        move |range, iovec| {
+            if range.start >= limit_offset {
+                StreamAction::Stop
+            } else if iovec.total_size() > max_record_size {
+                StreamAction::SkipRecord
+            } else {
+                StreamAction::KeepGoing
+            }
+        }
+    }
+
+    /// Returns the offset (in terms of bytes pulled from a reader)
+    /// for the first byte of the most recently read (highest offset)
+    /// stuff sequence sentinel.
+    #[must_use]
+    #[inline(always)]
+    pub fn last_sentinel_offset(&self) -> u64 {
+        self.last_sentinel_offset
+    }
+
+    /// Attempts to decode the next [`STUFF_SEQUENCE`] delimited record
+    /// from `reader`.
+    ///
+    /// When more data is needed, this method attempts to read from
+    /// `reader` in `io_block_size` (or [`DEFAULT_BLOCK_SIZE`] blocks.
+    ///
+    /// Calls the `record_judge` with the current byte range in the
+    /// stuffed input for the record the bytes decoded so far in order
+    /// to know what to do: keep attempting to decode the record, skip
+    /// the record, or stop reading (i.e., EOF).
+    ///
+    /// Returns an IO error if `reader` does, and None on EOF.  Otherwise,
+    /// returns a pair of:
+    ///  - an [`OwningIovec`] filled with the decoded record's contents
+    ///  - the range of encoded bytes read to yield this record
+    ///
+    /// Invalid HCOBS byte sequence are silently skipped (but still passed
+    /// to the `record_judge` for early exit).
+    pub fn next_record_bytes(
+        &mut self,
+        mut reader: impl std::io::Read,
+        mut record_judge: impl FnMut(Range<u64>, ConsumingIovec<'_>) -> StreamAction,
+        io_block_size: Option<usize>,
+    ) -> Result<Option<(&mut OwningIovec<'static>, Range<u64>)>> {
+        #[derive(PartialEq, Eq)]
+        enum State {
+            // We start here, until we hit a non-STUFF_SEQUENCE byte
+            SkipSentinel,
+            // Then keep decoding...
+            DecodeRecord,
+            // Until we hit an invalid encoded sequence, or the judge
+            // tells us to skip.
+            SkipRecord,
+        }
+
+        let io_block_size = io_block_size.unwrap_or(DEFAULT_BLOCK_SIZE);
+
+        'retry: loop {
+            self.iovec.clear();
+            let mut decoder = Decoder::new_from_iovec(self.iovec.take());
+
+            let mut state = State::SkipSentinel;
+            let mut range = 0u64..0u64;
+            loop {
+                assert_eq!(range.is_empty(), state == State::SkipSentinel);
+
+                match self
+                    .chunker
+                    .pump(decoder.consumer().arena(), &mut reader, io_block_size)?
+                {
+                    Chunk::Sentinel(offset) => {
+                        // The offset is the end byte.
+                        assert!(offset >= 2);
+                        self.last_sentinel_offset = offset - (STUFF_SEQUENCE.len() as u64);
+                        match state {
+                            State::SkipSentinel => range = offset..offset,
+                            // We hit a sentinel, so the record is complete.
+                            State::DecodeRecord | State::SkipRecord => break,
+                        }
+                    }
+                    Chunk::Eof => {
+                        // We hit EOF and didn't find any data chunk.  Bail.
+                        if range.is_empty() {
+                            return Ok(None);
+                        }
+
+                        break;
+                    }
+                    Chunk::Data((offset, slice)) => {
+                        // data slices are non-empty.
+                        assert!(!slice.slice().is_empty());
+
+                        match state {
+                            // We were in SkipSentinel state, so this is a new record.
+                            State::SkipSentinel => {
+                                let start = offset - (slice.slice().len() as u64);
+                                range = start..start;
+                                state = State::DecodeRecord
+                            }
+                            State::DecodeRecord => {}
+                            // Don't `continue`: let the judge have at it and decide if it's
+                            // time to just stop decoding.
+                            State::SkipRecord => {}
+                        }
+
+                        // Try to decode if we should
+                        if state == State::DecodeRecord && decoder.decode_anchored(slice).is_err() {
+                            // And skip the rest of the record if it's invalid.
+                            state = State::SkipRecord;
+                        }
+
+                        range.end = offset;
+                    }
+                }
+
+                match record_judge(range.clone(), decoder.consumer()) {
+                    StreamAction::KeepGoing => {}
+                    StreamAction::SkipRecord => state = State::SkipRecord,
+                    StreamAction::Stop => return Ok(None),
+                }
+            }
+
+            // We only get here from a DecodeRecord state (or EOF and range non-empty)
+            assert_ne!(&range.start, &range.end);
+
+            if state == State::SkipRecord {
+                self.iovec = decoder.take_iovec();
+                continue 'retry;
+            }
+
+            let Ok(iovec) = decoder.finish() else {
+                continue 'retry;
+            };
+
+            self.iovec = iovec;
+            return Ok(Some((&mut self.iovec, range)));
+        }
+    }
+}
+
+// Check that we can read a couple HCOBS records.
+#[test]
+fn test_stream_reader_miri() {
+    let payload: &[&[u8]] = &[
+        b"\x01a", // Missing stuff sequence here
+        &STUFF_SEQUENCE,
+        b"\x02bc",
+        &STUFF_SEQUENCE,
+        &STUFF_SEQUENCE,
+        b"\x03def",
+        &STUFF_SEQUENCE,
+        &STUFF_SEQUENCE, // extra stuff sequence
+        &STUFF_SEQUENCE,
+        b"\x03ghijk", // invalid
+        &STUFF_SEQUENCE,
+        b"\xffghijk", // invalid
+        &STUFF_SEQUENCE,
+        &STUFF_SEQUENCE,
+        b"\x071234567", // too long
+        &STUFF_SEQUENCE,
+        &STUFF_SEQUENCE,
+        b"\x01z",
+        // missing stuff sequence here
+    ];
+    let judge = StreamReader::chunk_judge(4, None);
+    let mut payload = &payload.concat()[..];
+
+    let mut reader = StreamReader::new();
+    let (iovec, pos) = reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .expect("must have data");
+    assert_eq!(pos, 0..2);
+
+    assert_eq!(iovec.flatten().expect("no backpatch"), b"a");
+
+    let (iovec, pos) = reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .expect("must have data");
+    assert_eq!(pos, 4..7);
+
+    assert_eq!(iovec.flatten().expect("no backpatch"), b"bc");
+
+    let (iovec, pos) = reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .expect("must have data");
+    assert_eq!(pos, 11..15);
+
+    assert_eq!(
+        iovec
+            .stable_prefix()
+            .iter()
+            .flat_map(|x| -> &[u8] { x })
+            .copied()
+            .collect::<Vec<u8>>(),
+        b"def"
+    );
+
+    let (iovec, pos) = reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .expect("must have data");
+    assert_eq!(pos, 51..53);
+
+    assert_eq!(iovec.flatten().expect("no backpatch"), b"z");
+
+    // Last record was at 51..53, so the sentinel just before was at 49.
+    assert_eq!(reader.last_sentinel_offset(), 49);
+
+    // Should hit EOF
+    assert!(reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .is_none());
+    // And stay there
+    assert!(reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .is_none());
+}
+
+// Confirm that we can stop reading after an offset.
+#[test]
+fn test_stream_reader_partial_miri() {
+    let contents: &[&[u8]] = &[b"\x01a", &STUFF_SEQUENCE, b"\x02bc"];
+    let mut payload = &contents.concat()[..];
+
+    let judge = StreamReader::chunk_judge(usize::MAX, None);
+    let mut reader = StreamReader::new();
+    let (iovec, pos) = reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .expect("must have data");
+    assert_eq!(pos, 0..2);
+    assert_eq!(iovec.flatten().expect("no backpatch"), b"a");
+    let (iovec, pos) = reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .expect("must have data");
+    assert_eq!(pos, 4..7);
+
+    assert_eq!(iovec.flatten().expect("no backpatch"), b"bc");
+
+    // Should hit EOF
+    assert!(reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .is_none());
+
+    // Now do the same thing, but stop after byte 1.
+    let judge = StreamReader::chunk_judge(usize::MAX, Some(1u64));
+    let mut payload = &contents.concat()[..];
+    let mut reader = StreamReader::new();
+    let (iovec, pos) = reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .expect("must have data");
+    assert_eq!(pos, 0..2);
+    assert_eq!(iovec.flatten().expect("no batckpatch"), b"a");
+
+    // Should immediately hit EOF
+    assert!(reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .is_none());
+
+    // Stop after byte 1, on a stuff sequence.
+    let contents: &[&[u8]] = &[b"\x01a", &STUFF_SEQUENCE, &STUFF_SEQUENCE, b"\x02bc"];
+
+    let judge = StreamReader::chunk_judge(usize::MAX, Some(1u64));
+    let mut payload = &contents.concat()[..];
+    let mut reader = StreamReader::new();
+    let (iovec, pos) = reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .expect("must have data");
+    assert_eq!(pos, 0..2);
+    assert_eq!(iovec.flatten().expect("no backpatch"), b"a");
+
+    // Should immediately hit EOF
+    assert!(reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .is_none());
+}
+
+// Empty file should direct return EOF
+#[test]
+fn test_stream_reader_empty_miri() {
+    let mut payload: &[u8] = &[];
+
+    let mut reader = StreamReader::new();
+    assert!(reader
+        .next_record_bytes(
+            &mut payload,
+            StreamReader::chunk_judge(usize::MAX, None),
+            TEST_BLOCK_SIZE
+        )
+        .expect("must succeed")
+        .is_none());
+}
+
+// Only a stuff sequence -> return EOF
+#[test]
+fn test_stream_reader_stuff_only_miri() {
+    let mut payload = &STUFF_SEQUENCE[..];
+
+    let mut reader = StreamReader::new();
+    assert!(reader
+        .next_record_bytes(
+            &mut payload,
+            StreamReader::chunk_judge(usize::MAX, None),
+            TEST_BLOCK_SIZE
+        )
+        .expect("must succeed")
+        .is_none());
+}
+
+// Couple stuff sequence -> data, should decode fine.
+#[test]
+fn test_stream_reader_many_stuff_miri() {
+    let payload: &[&[u8]] = &[&STUFF_SEQUENCE, &STUFF_SEQUENCE, b"\x00"];
+
+    let mut payload = &payload.concat()[..];
+    let mut reader = StreamReader::new();
+    let (iovec, pos) = reader
+        .next_record_bytes(
+            &mut payload,
+            StreamReader::chunk_judge(usize::MAX, None),
+            TEST_BLOCK_SIZE,
+        )
+        .expect("must succeed")
+        .expect("must have data");
+
+    let slices = iovec.stable_prefix();
+    assert_eq!(slices.len(), 0);
+    assert_eq!(pos, 4..5);
+}
+
+// Only one message should decode fine.
+#[test]
+fn test_stream_reader_one_message_miri() {
+    let mut payload = &b"\x01a"[..];
+
+    let mut reader = StreamReader::new();
+
+    let (iovec, pos) = reader
+        .next_record_bytes(
+            &mut payload,
+            StreamReader::chunk_judge(usize::MAX, None),
+            TEST_BLOCK_SIZE,
+        )
+        .expect("must succeed")
+        .expect("must have data");
+    assert_eq!(pos, 0..2);
+
+    assert_eq!(iovec.flatten().expect("no backpatch"), b"a");
+
+    assert!(reader
+        .next_record_bytes(
+            &mut payload,
+            StreamReader::chunk_judge(usize::MAX, None),
+            TEST_BLOCK_SIZE
+        )
+        .expect("must succeed")
+        .is_none());
+}
+
+// Rruncated messages should be skipped.
+#[test]
+fn test_stream_reader_truncated_message_miri() {
+    // Two truncated messages, one terminated by a stuff sequence,
+    // another by EOF.
+    let mut payload = &b"\x02a\xFE\xFD\x05b"[..];
+
+    let mut reader = StreamReader::new();
+
+    assert!(reader
+        .next_record_bytes(
+            &mut payload,
+            StreamReader::chunk_judge(usize::MAX, None),
+            TEST_BLOCK_SIZE
+        )
+        .expect("must succeed")
+        .is_none());
+}
+
+// We should gracefully bubble up an error in the middle of a
+// record.
+#[test]
+fn test_stream_reader_error_miri() {
+    struct Reader {
+        payload: &'static [u8],
+    }
+
+    impl std::io::Read for Reader {
+        fn read(&mut self, dst: &mut [u8]) -> Result<usize> {
+            if self.payload.is_empty() {
+                Err(std::io::Error::other("bad"))
+            } else {
+                let to_read = self.payload.len().min(dst.len());
+                dst[..to_read].copy_from_slice(&self.payload[..to_read]);
+                self.payload = &self.payload[to_read..];
+                Ok(to_read)
+            }
+        }
+    }
+
+    let mut payload = Reader {
+        payload: b"\x01a\xFE\xFD\x00",
+    };
+
+    let mut reader = StreamReader::new();
+
+    let (iovec, pos) = reader
+        .next_record_bytes(
+            &mut payload,
+            StreamReader::chunk_judge(usize::MAX, None),
+            TEST_BLOCK_SIZE,
+        )
+        .expect("must succeed")
+        .expect("must have data");
+    assert_eq!(pos, 0..2);
+    assert_eq!(iovec.flatten().expect("no backpatch"), b"a");
+
+    assert!(reader
+        .next_record_bytes(
+            &mut payload,
+            StreamReader::chunk_judge(usize::MAX, None),
+            TEST_BLOCK_SIZE
+        )
+        .is_err());
+}

--- a/sliding_deque/src/sorted_deque.rs
+++ b/sliding_deque/src/sorted_deque.rs
@@ -50,8 +50,8 @@ pub trait SortedDequeComparator<T> {
     /// Defaults to always false; should be overridden when
     /// `SortedDequeMarker` is implemented.
     #[inline(always)]
+    #[allow(unused_variables)] // The default implementation is a stub
     fn is_erased(&self, item: &T) -> bool {
-        let _ = item;
         false
     }
 }


### PR DESCRIPTION
The hcobs crate is an implementation of the Hybrid Consistent Overhead Byte Stuffing scheme of https://pvk.ca/Blog/2021/01/11/stuff-your-logs/

The encoder accepts an arbitrary sequence of bytes, and turns it into another byte sequence without the sentinel sequence 0xFE 0xFD (at any alignment).

The decoder accepts the result and turns it back into the original byte sequence.

The encoding overhead is at most 1 byte for messages < 254 bytes, 3 bytes for messages < 64769, and < 0.008% after that.

Both encoding and decoding take their input incrementally, and use the OwningIovec to both enable streaming consumption of their output, and for optional zero-copy.

The HCOBS encoding is often used to store self-delimiting records, where each record is encoded with HCOBS and surrounded by the 0xFE 0xFD sequence.  The write side is trivial; for readers, `StreamReader` pulls bytes from a `std::io::Read` and yields records, along with position metadata to resume consumption.

Start reading an encoder.rs, then decoder.rs and stream_reader.  The StreamReader is just a convenience wrapper around `Decoder`.