### PR TITLE
Add vouched_time crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 
 members = [
+  "hcobs",
   "owning_iovec",
   "sliding_deque",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "hcobs",
   "owning_iovec",
   "sliding_deque",
+  "vouched_time",
 ]
 
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 
 members = [
+  "owning_iovec",
   "sliding_deque",
 ]
 

--- a/hcobs/Cargo.toml
+++ b/hcobs/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "hcobs"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+owning_iovec = { path = "../owning_iovec" }
+
+[dev-dependencies]
+rusty-fork = "0.3"
+
+[lints]
+workspace = true

--- a/hcobs/src/decoder.rs
+++ b/hcobs/src/decoder.rs
@@ -1,0 +1,600 @@
+use crate::Parameters;
+use crate::RADIX;
+use crate::STUFF_SEQUENCE;
+#[cfg(test)]
+use crate::TEST_PARAMS;
+
+use std::num::NonZeroU32;
+
+use owning_iovec::OwningIovec;
+
+/// The initial state for the HCOBS decoder.  We're expecting the first chunk
+/// of data.
+///
+/// The initial state is special because the first chunk has a one-byte size
+/// header.
+#[derive(Debug, Eq, PartialEq)]
+pub struct InitialState {}
+
+/// The other reset state for the HCOBS decoder, between chunks.  We're
+/// waiting for a subsequent (not the first) chunk of data.
+///
+/// Subsequent chunks differ from the initial chunk because they have a
+/// two-byte size header. The `should insert_stuff_sequence` field indicates
+/// whether a `STUFF_SEQUENCE` should be inserted at the start of the next
+/// chunk.  We don't producer the `STUFF_SEQUENCE` eagerly because the last
+/// one in an encoded sequence is an fake sequence that acts as a terminator.
+#[derive(Debug, Eq, PartialEq)]
+pub struct BeforeChunk {
+    should_insert_stuff_sequence: bool,
+}
+
+/// The state of the HCOBS decoder after processing the first byte of a chunk
+/// size header; that first byte is stored in `initial_byte`.
+#[derive(Debug, Eq, PartialEq)]
+pub struct MidHeader {
+    initial_byte: u8,
+}
+
+/// The state of the HCOBS decoder when decoding a size-prefixed chunk.
+///
+/// The `remaining` field indicates the number of bytes remaining in the
+/// current chunk, and the `terminate_with_stuff_sequence` field indicates
+/// whether the chunk should be terminated with a `STUFF_SEQUENCE`.
+#[derive(Debug, Eq, PartialEq)]
+pub struct InChunk {
+    remaining: NonZeroU32,
+    terminate_with_stuff_sequence: bool,
+}
+
+/// Represents the different states of the HCOBS decoder during the decoding
+/// process.
+#[derive(Debug, Eq, PartialEq)]
+pub enum DecoderState {
+    InitialState(InitialState),
+    BeforeChunk(BeforeChunk),
+    MidHeader(MidHeader),
+    InChunk(InChunk),
+}
+
+/// Failure reasons for decoding with [`Decoder`]
+///
+/// HCOBS-encoded data is partitioned in length-value segments, where the
+/// values are arbitrary (they *shouldn't* contain the [`STUFF_SEQUENCE`], but
+/// that's irrelevant for decoding).  The only validation happens for the
+/// length headers: lengths are in radix-253, so high bytes are invalid.  We
+/// also expect the HCOBS-encoded value to end exactly at a segment with an
+/// implicit [`STUFF_SEQUENCE`] at the end, so short inputs can also error
+/// out.
+///
+/// This format is robust, and there are many ways for a corrupt or truncated
+/// encoded stream to still decode correctly. Encoded data should come with a
+/// checksum mechanism (e.g., embedded in each encoded payload).
+///
+/// [`Decoder`]: [`crate::Decoder`]
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub enum DecodingError {
+    /// The first byte in an HCOBS-encoded stream must be a 1-byte
+    /// size header for the initial segment.  This value is in radix
+    /// 253, so 253, 254, and 255 are invalid.
+    ///
+    /// The payload is the invalid byte.
+    InvalidInitialSizeHeader(u8),
+    /// Subsequent segments start with a 2-byte (little-endian) size header,
+    /// in radix 253 again.  The payload is the index of the byte, and
+    /// the invalid byte value.
+    InvalidHeaderByte((bool, u8)),
+    /// In test configurations, a 2-byte size header may be a valid radix-253
+    /// value but too large for a size header.
+    ///
+    /// The payload is that invalid size.
+    InvalidSubsequentSizeHeader(usize),
+    /// We expect input streams to end at a segment boundary.  It's an error
+    /// if the stream ends and we're not waiting for the first byte in a
+    /// chunk header.
+    CutShort,
+    /// We expect input streams to end after a short (less than maximum length)
+    /// segment: these segments denote an implicit [`STUFF_SEQUENCE`] between
+    /// the segment that just ended and the next.  For the final segment, it
+    /// simply means that we correctly reached the end.
+    MissingImplicitTerminator,
+}
+
+impl std::fmt::Display for DecodingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use DecodingError::*;
+        match self {
+            InvalidInitialSizeHeader(byte) => write!(
+                f,
+                "HCOBS decoding error: invalid initial chunk size. byte={}",
+                byte
+            ),
+            InvalidHeaderByte((second, byte)) => write!(
+                f,
+                "HCOBS decoding error: invalid subsequent chunk header byte. index={} byte={}",
+                *second as u8, byte
+            ),
+            InvalidSubsequentSizeHeader(size) => write!(
+                f,
+                "HCOBS decoding error: invalid subsequent size. size={}",
+                size
+            ),
+            CutShort => write!(f, "HCOBS decoding error: decoding terminated mid-chunk"),
+            MissingImplicitTerminator => write!(f, "HCOBS decoding error: decoding terminated without implicit stuff sequence terminator"),
+        }
+    }
+}
+
+impl std::error::Error for DecodingError {}
+
+pub type Result<T> = std::result::Result<T, DecodingError>;
+
+impl Default for DecoderState {
+    #[inline(always)]
+    fn default() -> Self {
+        DecoderState::new()
+    }
+}
+
+impl DecoderState {
+    /// Creates a new `DecoderState` in the initial state.
+    #[inline(always)]
+    pub fn new() -> DecoderState {
+        DecoderState::InitialState(InitialState {})
+    }
+
+    /// Terminates the decoding process.
+    ///
+    /// Returns an error if the decoder was not stopped at the end of a chunk
+    /// with an implicit stuff sequence terminator (i.e., was stopped early).
+    #[inline(always)]
+    pub fn terminate(self) -> Result<()> {
+        match self {
+            DecoderState::BeforeChunk(state) => {
+                if state.should_insert_stuff_sequence {
+                    // We must have a stuff sequence pending if we terminate
+                    Ok(())
+                } else {
+                    Err(DecodingError::MissingImplicitTerminator)
+                }
+            }
+            _ => Err(DecodingError::CutShort),
+        }
+    }
+
+    /// Decodes the contents of an input slice into an [`OwningIovec`].
+    ///
+    /// Returns an error if there is any decoding error, otherwise consumes
+    /// the whole slice.
+    pub fn decode_borrow<'slices>(
+        mut self,
+        iovec: &mut OwningIovec<'slices>,
+        params: Parameters,
+        mut input: &'slices [u8],
+    ) -> Result<Self> {
+        while !input.is_empty() {
+            let consumed;
+
+            // Each `decode` call advances the state machine by one state.
+            (self, consumed) = match self {
+                DecoderState::InitialState(state) => state.decode(iovec, params, input)?,
+                DecoderState::BeforeChunk(state) => state.decode(iovec, params, input)?,
+                DecoderState::MidHeader(state) => state.decode(iovec, params, input)?,
+                DecoderState::InChunk(state) => state.decode_borrow(iovec, params, input),
+            };
+
+            input = &input[consumed..];
+        }
+
+        Ok(self)
+    }
+
+    /// Decodes the contents of an input slice into an [`OwningIovec`], while
+    /// unconditionally copying bytes into fresh slices owned by `iovec`.
+    ///
+    /// Returns an error if there is any decoding error, otherwise consumes
+    /// the whole slice.
+    pub fn decode_copy(
+        mut self,
+        iovec: &mut OwningIovec<'_>,
+        params: Parameters,
+        mut input: &[u8],
+    ) -> Result<Self> {
+        while !input.is_empty() {
+            let consumed;
+
+            (self, consumed) = match self {
+                DecoderState::InitialState(state) => state.decode(iovec, params, input)?,
+                DecoderState::BeforeChunk(state) => state.decode(iovec, params, input)?,
+                DecoderState::MidHeader(state) => state.decode(iovec, params, input)?,
+                DecoderState::InChunk(state) => state.decode_copy(iovec, params, input),
+            };
+
+            input = &input[consumed..];
+        }
+
+        Ok(self)
+    }
+}
+
+impl InitialState {
+    fn decode(
+        self,
+        _iovec: &mut OwningIovec<'_>,
+        params: Parameters,
+        input: &[u8],
+    ) -> Result<(DecoderState, usize)> {
+        assert!(!input.is_empty());
+
+        let chunk_size = input[0] as usize;
+        let max_initial_size: usize = params.max_initial_size.into();
+        if chunk_size > max_initial_size {
+            return Err(DecodingError::InvalidInitialSizeHeader(chunk_size as u8));
+        }
+
+        let terminate_with_stuff_sequence = chunk_size < max_initial_size;
+        if chunk_size > 0 {
+            Ok((
+                DecoderState::InChunk(InChunk {
+                    remaining: NonZeroU32::new(chunk_size as u32).unwrap(),
+                    terminate_with_stuff_sequence,
+                }),
+                1,
+            ))
+        } else {
+            Ok((
+                DecoderState::BeforeChunk(BeforeChunk {
+                    should_insert_stuff_sequence: terminate_with_stuff_sequence,
+                }),
+                1,
+            ))
+        }
+    }
+}
+
+impl BeforeChunk {
+    fn decode(
+        self,
+        iovec: &mut OwningIovec<'_>,
+        _params: Parameters,
+        input: &[u8],
+    ) -> Result<(DecoderState, usize)> {
+        assert!(!input.is_empty());
+
+        if self.should_insert_stuff_sequence {
+            iovec.push_copy(&STUFF_SEQUENCE);
+        }
+
+        let initial_byte = input[0];
+        if initial_byte as usize >= RADIX {
+            Err(DecodingError::InvalidHeaderByte((false, initial_byte)))
+        } else {
+            Ok((DecoderState::MidHeader(MidHeader { initial_byte }), 1))
+        }
+    }
+}
+
+impl MidHeader {
+    fn decode(
+        self,
+        _iovec: &mut OwningIovec<'_>,
+        params: Parameters,
+        input: &[u8],
+    ) -> Result<(DecoderState, usize)> {
+        assert!(!input.is_empty());
+
+        let second_byte = input[0] as usize;
+        if second_byte >= RADIX {
+            return Err(DecodingError::InvalidHeaderByte((true, second_byte as u8)));
+        }
+
+        let chunk_size = (self.initial_byte as usize) + (second_byte * RADIX);
+        let max_subsequent_size: usize = params.max_subsequent_size.into();
+
+        if chunk_size > max_subsequent_size {
+            return Err(DecodingError::InvalidSubsequentSizeHeader(chunk_size));
+        }
+
+        let terminate_with_stuff_sequence = chunk_size < max_subsequent_size;
+        if chunk_size > 0 {
+            Ok((
+                DecoderState::InChunk(InChunk {
+                    remaining: NonZeroU32::new(chunk_size as u32).unwrap(),
+                    terminate_with_stuff_sequence,
+                }),
+                1,
+            ))
+        } else {
+            Ok((
+                DecoderState::BeforeChunk(BeforeChunk {
+                    should_insert_stuff_sequence: terminate_with_stuff_sequence,
+                }),
+                1,
+            ))
+        }
+    }
+}
+
+impl InChunk {
+    fn update(mut self, bytes_consumed: usize) -> (DecoderState, usize) {
+        if bytes_consumed < self.remaining.get() as usize {
+            self.remaining = NonZeroU32::new(self.remaining.get() - bytes_consumed as u32).unwrap();
+            (DecoderState::InChunk(self), bytes_consumed)
+        } else {
+            assert_eq!(self.remaining.get(), bytes_consumed as u32);
+            let should_insert_stuff_sequence = self.terminate_with_stuff_sequence;
+            (
+                DecoderState::BeforeChunk(BeforeChunk {
+                    should_insert_stuff_sequence,
+                }),
+                bytes_consumed,
+            )
+        }
+    }
+
+    fn decode_borrow<'slices>(
+        self,
+        iovec: &mut OwningIovec<'slices>,
+        _params: Parameters,
+        input: &'slices [u8],
+    ) -> (DecoderState, usize) {
+        assert!(!input.is_empty());
+
+        let bytes_consumed = input.len().min(self.remaining.get() as usize);
+        iovec.push(&input[..bytes_consumed]);
+        self.update(bytes_consumed)
+    }
+
+    fn decode_copy(
+        self,
+        iovec: &mut OwningIovec<'_>,
+        _params: Parameters,
+        input: &[u8],
+    ) -> (DecoderState, usize) {
+        assert!(!input.is_empty());
+
+        let bytes_consumed = input.len().min(self.remaining.get() as usize);
+        iovec.push_copy(&input[..bytes_consumed]);
+        self.update(bytes_consumed)
+    }
+}
+
+#[cfg(test)]
+fn decode_with_test_params(bytes: &[u8]) -> Result<Vec<u8>> {
+    let decode_one = || {
+        let mut iovec = OwningIovec::new();
+        let mut decoder = DecoderState::new();
+
+        decoder = decoder.decode_borrow(&mut iovec, TEST_PARAMS, bytes)?;
+        decoder.terminate()?;
+
+        Ok(iovec.flatten().expect("no backpatch left"))
+    };
+
+    // Redundantly decode with copy and check it's the same result
+    let decode_two = || -> Result<Vec<u8>> {
+        let mut iovec = OwningIovec::new();
+        let mut decoder: DecoderState = Default::default();
+
+        for byte in bytes {
+            decoder = decoder.decode_copy(&mut iovec, TEST_PARAMS, &[*byte])?;
+        }
+
+        decoder.terminate()?;
+
+        Ok(iovec.flatten().expect("no backpatch left"))
+    };
+
+    let ret = decode_one();
+    let redundant = decode_two();
+
+    assert_eq!(ret.is_err(), redundant.is_err());
+    ret
+}
+
+// Test some expected input/output pairs
+#[test]
+fn test_simple_miri() {
+    assert_eq!(decode_with_test_params(b"\x00").unwrap(), b"");
+    assert_eq!(decode_with_test_params(b"\x011").unwrap(), b"1");
+    assert_eq!(decode_with_test_params(b"\x0212").unwrap(), b"12");
+    assert_eq!(decode_with_test_params(b"\x03123\x00\x00").unwrap(), b"123");
+    assert_eq!(
+        decode_with_test_params(b"\x03123\x04\x004567").unwrap(),
+        b"1234567"
+    );
+    assert_eq!(
+        decode_with_test_params(b"\x03123\x05\x0045678\x00\x00").unwrap(),
+        b"12345678"
+    );
+    assert_eq!(
+        decode_with_test_params(b"\x03123\x05\x0045678\x01\x009").unwrap(),
+        b"123456789"
+    );
+    assert_eq!(
+        decode_with_test_params(b"\x00\x00\x00").unwrap(),
+        b"\xFE\xFD"
+    );
+    assert_eq!(
+        decode_with_test_params(b"\x011\x00\x00").unwrap(),
+        b"1\xFE\xFD"
+    );
+    assert_eq!(
+        decode_with_test_params(b"\x0312\xFE\x01\x00\xFD").unwrap(),
+        b"12\xFE\xFD"
+    );
+    assert_eq!(
+        decode_with_test_params(b"\x03123\x00\x00\x00\x00").unwrap(),
+        b"123\xFE\xFD"
+    );
+    assert_eq!(
+        decode_with_test_params(b"\x03123\x01\x004\x01\x00\xFE").unwrap(),
+        b"1234\xFE\xFD\xFE"
+    );
+    assert_eq!(
+        decode_with_test_params(b"\x03123\x02\x004\xFE\x00\x00").unwrap(),
+        b"1234\xFE\xFE\xFD"
+    );
+    assert_eq!(
+        decode_with_test_params(b"\x03123\x04\x004\xFE\xFE\xFE").unwrap(),
+        b"1234\xFE\xFE\xFE"
+    );
+    assert_eq!(
+        decode_with_test_params(b"\x03123\x04\x004\xFD\xFD\xFD").unwrap(),
+        b"1234\xFD\xFD\xFD"
+    );
+}
+
+#[test]
+fn test_error_miri() {
+    // Bad initial header
+
+    // Truncated
+    assert!(decode_with_test_params(b"\x01").is_err());
+    // No terminating chunk
+    assert!(decode_with_test_params(b"\x03123").is_err());
+
+    // Bad radix
+    assert!(decode_with_test_params(b"\xff").is_err());
+    // Too long
+    assert!(decode_with_test_params(b"\x0f").is_err());
+
+    // Truncated first chunk
+    assert!(decode_with_test_params(b"\x021").is_err());
+
+    // No terminating chunk
+    assert!(decode_with_test_params(b"\x03123").is_err());
+
+    // Bad second header (first byte)
+    assert!(decode_with_test_params(b"\x03123\xff").is_err());
+
+    // Bad second header (second byte)
+    assert!(decode_with_test_params(b"\x03123\x00\xff").is_err());
+
+    // Bad second header (too large)
+    assert!(decode_with_test_params(b"\x03123\x00\x01").is_err());
+
+    // Truncated second chunk
+    assert!(decode_with_test_params(b"\x03123\x01\x00").is_err());
+
+    // No terminating chunk
+    assert!(decode_with_test_params(b"\x03123\x05\x0045678").is_err());
+}
+
+#[cfg(test)]
+fn compare_decode_with_test_params(
+    contiguous: &[u8],
+    initial: &[u8],
+    last: &[u8],
+    split: &[&[u8]],
+) {
+    let decode_zero = || -> Result<(DecoderState, Vec<u8>)> {
+        let mut iovec = OwningIovec::new();
+        let mut decoder = DecoderState::new();
+
+        decoder = decoder.decode_borrow(&mut iovec, TEST_PARAMS, contiguous)?;
+
+        Ok((decoder, iovec.flatten().expect("no backpatch left")))
+    };
+
+    let decode_one = || -> Result<(DecoderState, Vec<u8>)> {
+        let mut iovec = OwningIovec::new();
+        let mut decoder = DecoderState::new();
+
+        decoder = decoder.decode_borrow(&mut iovec, TEST_PARAMS, initial)?;
+        decoder = decoder.decode_borrow(&mut iovec, TEST_PARAMS, last)?;
+
+        Ok((decoder, iovec.flatten().expect("no backpatch left")))
+    };
+
+    let decode_two = || -> Result<(DecoderState, Vec<u8>)> {
+        let mut iovec = OwningIovec::new();
+        let mut decoder = DecoderState::new();
+
+        decoder = decoder.decode_copy(&mut iovec, TEST_PARAMS, initial)?;
+        for (idx, slice) in split.iter().enumerate() {
+            if (idx % 2) == 0 {
+                decoder = decoder.decode_borrow(&mut iovec, TEST_PARAMS, slice)?;
+            } else {
+                decoder = decoder.decode_copy(&mut iovec, TEST_PARAMS, slice)?;
+            }
+        }
+
+        Ok((decoder, iovec.flatten().expect("no backpatch left")))
+    };
+
+    let contiguous_result = decode_zero();
+    let first_result = decode_one();
+    let second_result = decode_two();
+
+    assert_eq!(contiguous_result.is_err(), first_result.is_err());
+    assert_eq!(first_result.is_err(), second_result.is_err());
+
+    if first_result.is_ok() {
+        let contiguous_result = contiguous_result.unwrap();
+        let first_result = first_result.unwrap();
+        let second_result = second_result.unwrap();
+
+        assert_eq!(contiguous_result, first_result);
+        assert_eq!(first_result, second_result);
+    }
+}
+
+// Start decoding up to `start`, the fork decoding (one incremental, one not),
+// and confirm we have the same final state.
+#[test]
+fn test_incremental_slow() {
+    let patterns = &[
+        b"\x03123\x02\x004\xFE\x00\x00",
+        b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09",
+        b"\x0212\x05\x0045678",
+        b"\x00\x05\x0045678\x00\x00",
+    ];
+
+    #[cfg(miri)]
+    let patterns = &patterns[..2];
+
+    for pattern in patterns {
+        for start in 0..pattern.len() {
+            for end in (start + 1)..=pattern.len() {
+                for mid in start..=end {
+                    compare_decode_with_test_params(
+                        &pattern[..end],
+                        &pattern[..start],
+                        &pattern[start..end],
+                        &[&pattern[start..mid], &pattern[mid..end]],
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test_error_display() {
+    assert_eq!(
+        format!("{}", DecodingError::InvalidInitialSizeHeader(254)),
+        "HCOBS decoding error: invalid initial chunk size. byte=254"
+    );
+    assert_eq!(
+        format!("{}", DecodingError::InvalidHeaderByte((false, 255))),
+        "HCOBS decoding error: invalid subsequent chunk header byte. index=0 byte=255"
+    );
+    assert_eq!(
+        format!("{}", DecodingError::InvalidHeaderByte((true, 254))),
+        "HCOBS decoding error: invalid subsequent chunk header byte. index=1 byte=254"
+    );
+    assert_eq!(
+        format!("{}", DecodingError::InvalidSubsequentSizeHeader(254 * 255)),
+        "HCOBS decoding error: invalid subsequent size. size=64770"
+    );
+    assert_eq!(
+        format!("{}", DecodingError::CutShort),
+        "HCOBS decoding error: decoding terminated mid-chunk"
+    );
+    assert_eq!(
+        format!("{}", DecodingError::MissingImplicitTerminator),
+        "HCOBS decoding error: decoding terminated without implicit stuff sequence terminator"
+    );
+}

--- a/hcobs/src/encoder.rs
+++ b/hcobs/src/encoder.rs
@@ -1,0 +1,380 @@
+use crate::find_stuff_sequence;
+use crate::Parameters;
+use crate::PROD_PARAMS;
+use crate::RADIX;
+use crate::STUFF_SEQUENCE;
+#[cfg(test)]
+use crate::TEST_PARAMS;
+
+use std::num::NonZeroUsize;
+
+use owning_iovec::Backref;
+use owning_iovec::OwningIovec;
+
+#[derive(Debug)]
+pub struct EncoderState {
+    // Initially `max_initial_size`, then `max_subsequent_size` for subsequent
+    // chunks.
+    max_chunk_size: NonZeroUsize,
+    // How many bytes we've accumulated in the chunk so far.  Once this reaches
+    // `max_chunk_size`, we must terminate the chunk.
+    current_chunk_size: usize,
+    // True if we might have stopped encoding in the middle of a stuff sequence,
+    // and must wait for the next byte to know for sure (if it is, we must
+    // terminate the chunk).
+    maybe_mid_stuff: bool,
+    // Backreference to the size header for the current chunk.
+    backref: Backref,
+}
+
+impl Default for EncoderState {
+    fn default() -> Self {
+        EncoderState {
+            max_chunk_size: PROD_PARAMS.max_initial_size,
+            current_chunk_size: 0,
+            maybe_mid_stuff: false,
+            backref: Default::default(),
+        }
+    }
+}
+
+impl EncoderState {
+    pub fn new(iovec: &mut OwningIovec<'_>, params: Parameters) -> Self {
+        EncoderState {
+            max_chunk_size: params.max_initial_size,
+            current_chunk_size: 0,
+            maybe_mid_stuff: false,
+            backref: iovec.register_patch(&[0u8]),
+        }
+    }
+
+    fn new_subsequent(iovec: &mut OwningIovec<'_>, params: Parameters) -> Self {
+        EncoderState {
+            max_chunk_size: params.max_subsequent_size,
+            current_chunk_size: 0,
+            maybe_mid_stuff: false,
+            backref: iovec.register_patch(&[0u8, 0u8]),
+        }
+    }
+
+    pub fn encode_borrow<'slices>(
+        mut self,
+        iovec: &mut OwningIovec<'slices>,
+        params: Parameters,
+        mut input: &'slices [u8],
+    ) -> Self {
+        while !input.is_empty() {
+            // If `maybe_mid_stuff`, we're buffering one byte, because it's
+            // equal to `STUFF_SEQUENCE[0]`.
+            let had_buffered_data = self.maybe_mid_stuff;
+            let consumed;
+
+            (self, consumed) = self.consume_once(iovec, params, input, |this, iovec, prefix| {
+                this.write(iovec, &input[0..prefix]);
+            });
+
+            // Can't consume too much.
+            assert!(consumed <= input.len());
+            // We should usually consume something, but it's possible to not
+            // consume anything if we instead dumped our internal buffered byte.
+            assert!((consumed > 0) | (!self.maybe_mid_stuff & had_buffered_data));
+
+            input = &input[consumed..];
+        }
+
+        self
+    }
+
+    pub fn encode_copy(
+        mut self,
+        iovec: &mut OwningIovec<'_>,
+        params: Parameters,
+        mut input: &[u8],
+    ) -> Self {
+        while !input.is_empty() {
+            // If `maybe_mid_stuff`, we're buffering one byte, because it's
+            // equal to `STUFF_SEQUENCE[0]`.
+            let had_buffered_data = self.maybe_mid_stuff;
+            let consumed;
+
+            (self, consumed) = self.consume_once(iovec, params, input, |this, iovec, prefix| {
+                this.copy(iovec, &input[0..prefix]);
+            });
+
+            // Can't consume too much.
+            assert!(consumed <= input.len());
+            // We should usually consume something, but it's possible to not
+            // consume anything if we instead dumped our internal buffered byte.
+            assert!((consumed > 0) | (!self.maybe_mid_stuff & had_buffered_data));
+
+            input = &input[consumed..];
+        }
+
+        self
+    }
+
+    pub fn terminate(mut self, iovec: &mut OwningIovec<'_>) {
+        if self.maybe_mid_stuff {
+            self.write_partial_stuff_sequence(iovec);
+        }
+
+        assert!(self.current_chunk_size < self.max_chunk_size.get());
+        Self::encode_header(self.current_chunk_size, iovec, self.backref);
+    }
+
+    fn encode_header(chunk_size: usize, iovec: &mut OwningIovec<'_>, backref: Backref) {
+        assert!(chunk_size < RADIX * RADIX);
+
+        let header = [(chunk_size % RADIX) as u8, (chunk_size / RADIX) as u8, 0];
+        let len = backref.len();
+        assert!((1..=2).contains(&len));
+        assert!(header[len] == 0);
+
+        iovec.backfill_or_panic(backref, &header[0..len]);
+    }
+
+    #[inline(never)]
+    fn write<'slices>(&mut self, iovec: &mut OwningIovec<'slices>, payload: &'slices [u8]) {
+        if payload.is_empty() {
+            return;
+        }
+
+        iovec.push(payload);
+        self.current_chunk_size += payload.len();
+        assert!(self.current_chunk_size <= self.max_chunk_size.get());
+    }
+
+    #[inline(never)]
+    fn copy(&mut self, iovec: &mut OwningIovec<'_>, payload: &[u8]) {
+        if payload.is_empty() {
+            return;
+        }
+
+        iovec.push_copy(payload);
+        self.current_chunk_size += payload.len();
+        assert!(self.current_chunk_size <= self.max_chunk_size.get());
+    }
+
+    #[inline(always)]
+    fn write_partial_stuff_sequence(&mut self, iovec: &mut OwningIovec<'_>) {
+        iovec.push_copy(&[STUFF_SEQUENCE[0]]);
+        self.current_chunk_size += 1;
+        assert!(self.current_chunk_size <= self.max_chunk_size.get());
+    }
+
+    fn consume_once<'slices>(
+        mut self,
+        iovec: &mut OwningIovec<'slices>,
+        params: Parameters,
+        mut input: &[u8],
+        // writer writes the `usize` prefix of `input` to the iovec.
+        writer: impl FnOnce(&mut Self, &mut OwningIovec<'slices>, usize),
+    ) -> (Self, usize) {
+        assert!(!input.is_empty());
+        assert!(
+            self.current_chunk_size + (self.maybe_mid_stuff as usize) < self.max_chunk_size.get()
+        );
+
+        // How many bytes we consumed before terminating the chunk
+        let consumed = if self.maybe_mid_stuff & (input[0] == STUFF_SEQUENCE[1]) {
+            // Completed a stuff between two slices sequence, write out the header!
+            1
+        } else {
+            assert!(self.current_chunk_size < self.max_chunk_size.get());
+
+            if self.maybe_mid_stuff {
+                // We buffered the previous slice's last byte. Write it out.
+                self.write_partial_stuff_sequence(iovec);
+                // If this was the last byte, we would have flushed it.
+                assert!(self.current_chunk_size < self.max_chunk_size.get());
+            }
+
+            let remaining = self.max_chunk_size.get() - self.current_chunk_size;
+            input = &input[..input.len().min(remaining)];
+
+            // remaining > 0 and input is initially non-empty.
+            assert!(!input.is_empty());
+
+            // See if we found the end of a chunk.
+            let (num_to_write, consumed) = if let Some(index) = find_stuff_sequence(input) {
+                // We found a stuff sequence before the mandatory end of chunk.
+                (index, index + STUFF_SEQUENCE.len())
+            } else if input.len() == remaining {
+                // We got to the mandatory end of the chunk.
+                (remaining, remaining)
+            } else {
+                // we're definitely not done with the chunk sequence.
+                let ret = input.len();
+
+                // If the slice's last byte matches the first of the stuff sequence,
+                // we can't write it out just yet.
+                self.maybe_mid_stuff = input[input.len() - 1] == STUFF_SEQUENCE[0];
+                let to_copy = if self.maybe_mid_stuff { ret - 1 } else { ret };
+
+                writer(&mut self, iovec, to_copy);
+
+                assert!(
+                    self.current_chunk_size + (self.maybe_mid_stuff as usize)
+                        < self.max_chunk_size.get()
+                );
+                return (self, ret);
+            };
+
+            writer(&mut self, iovec, num_to_write);
+            consumed
+        };
+
+        Self::encode_header(self.current_chunk_size, iovec, self.backref);
+        (Self::new_subsequent(iovec, params), consumed)
+    }
+}
+
+#[cfg(test)]
+fn encode_with_test_params(bytes: &[u8]) -> Vec<u8> {
+    let mut iovec = OwningIovec::new();
+    let mut encoder = EncoderState::new(&mut iovec, TEST_PARAMS);
+
+    encoder = encoder.encode_borrow(&mut iovec, TEST_PARAMS, bytes);
+    encoder.terminate(&mut iovec);
+
+    let ret = iovec.flatten().expect("no backpatch left");
+
+    // Redundantly encode with copy and check it's the same result
+    {
+        let mut iovec = OwningIovec::new();
+        let mut encoder = EncoderState::new(&mut iovec, TEST_PARAMS);
+
+        encoder = encoder.encode_copy(&mut iovec, TEST_PARAMS, bytes);
+        encoder.terminate(&mut iovec);
+
+        assert_eq!(&iovec.flatten().expect("no backpatch left"), &ret);
+    }
+
+    assert_eq!(super::find_stuff_sequence(&ret), None);
+
+    ret
+}
+
+// Test some expected input/output pairs
+#[test]
+fn test_simple_miri() {
+    assert_eq!(encode_with_test_params(b""), b"\x00");
+    assert_eq!(encode_with_test_params(b"1"), b"\x011");
+    assert_eq!(encode_with_test_params(b"12"), b"\x0212");
+    assert_eq!(encode_with_test_params(b"123"), b"\x03123\x00\x00");
+    assert_eq!(encode_with_test_params(b"1234567"), b"\x03123\x04\x004567");
+    assert_eq!(
+        encode_with_test_params(b"12345678"),
+        b"\x03123\x05\x0045678\x00\x00"
+    );
+    assert_eq!(
+        encode_with_test_params(b"123456789"),
+        b"\x03123\x05\x0045678\x01\x009"
+    );
+    assert_eq!(encode_with_test_params(b"\xFE\xFD"), b"\x00\x00\x00");
+    assert_eq!(encode_with_test_params(b"1\xFE\xFD"), b"\x011\x00\x00");
+    assert_eq!(
+        encode_with_test_params(b"12\xFE\xFD"),
+        b"\x0312\xFE\x01\x00\xFD"
+    );
+    assert_eq!(
+        encode_with_test_params(b"123\xFE\xFD"),
+        b"\x03123\x00\x00\x00\x00"
+    );
+    assert_eq!(
+        encode_with_test_params(b"1234\xFE\xFD\xFE"),
+        b"\x03123\x01\x004\x01\x00\xFE"
+    );
+    assert_eq!(
+        encode_with_test_params(b"1234\xFE\xFE\xFD"),
+        b"\x03123\x02\x004\xFE\x00\x00"
+    );
+    assert_eq!(
+        encode_with_test_params(b"1234\xFE\xFE\xFE"),
+        b"\x03123\x04\x004\xFE\xFE\xFE"
+    );
+    assert_eq!(
+        encode_with_test_params(b"1234\xFD\xFD\xFD"),
+        b"\x03123\x04\x004\xFD\xFD\xFD"
+    );
+}
+
+// Split a bunch of test vectors in different places, make sure the
+// the result is the same.
+//
+// The idea is that the encoding is deterministic function of the
+// current state and the input slice, and that terminating the
+// encoding captures the current state pretty well.
+#[cfg(test)]
+fn compare_encode_with_test_params(contiguous: &[u8], split: &[&[u8]]) {
+    let contiguous_encoded = encode_with_test_params(contiguous);
+
+    let mut iovec = OwningIovec::new();
+    let mut encoder = EncoderState::new(&mut iovec, TEST_PARAMS);
+
+    for subslice in split.iter().copied() {
+        encoder = encoder.encode_copy(&mut iovec, TEST_PARAMS, subslice);
+    }
+
+    encoder.terminate(&mut iovec);
+
+    let split_encoded = iovec.flatten().expect("no backpatch left");
+
+    // Same thing with borrow and copy.
+    for should_copy in [[false, false], [true, false], [false, true]] {
+        // we already did copy everything
+        let mut iovec = OwningIovec::new();
+        let mut encoder = EncoderState::new(&mut iovec, TEST_PARAMS);
+
+        for (idx, subslice) in split.iter().copied().enumerate() {
+            if should_copy[idx % 2] {
+                encoder = encoder.encode_borrow(&mut iovec, TEST_PARAMS, subslice);
+            } else {
+                encoder = encoder.encode_copy(&mut iovec, TEST_PARAMS, subslice);
+            }
+        }
+
+        encoder.terminate(&mut iovec);
+
+        assert_eq!(
+            &split_encoded,
+            &iovec.flatten().unwrap() // ,
+                                      // "should_copy={:?}",
+                                      // should_copy
+        );
+    }
+
+    assert_eq!(
+        contiguous_encoded,
+        split_encoded // ,
+                      // "contiguous={:?}\nsplit={:?}\n => {:?}\n => {:?}",
+                      // contiguous, split, contiguous_encoded, split_encoded
+    );
+}
+
+#[test]
+fn test_split_slow() {
+    let patterns = &[
+        b"123456789abcdef",
+        b"12345678\xFE\xFD\xFEabcd",
+        b"12345678\xFE\xFE\xFEabcd",
+        b"12345678\xFD\xFD\xFDabcd",
+        b"12345678\xFD\xFE\xFDabcd",
+    ];
+
+    #[cfg(miri)]
+    let patterns = &patterns[..2];
+
+    for pattern in patterns {
+        for start in 0..pattern.len() {
+            for end in (start + 1)..=pattern.len() {
+                for mid in start..=end {
+                    compare_encode_with_test_params(
+                        &pattern[start..end],
+                        &[&pattern[start..mid], &pattern[mid..end]],
+                    );
+                }
+            }
+        }
+    }
+}

--- a/hcobs/src/lib.rs
+++ b/hcobs/src/lib.rs
@@ -1,0 +1,674 @@
+//! The `hcobs` crate implements the hybrid consistent-overhead byte/word
+//! stuffing scheme of <https://pvk.ca/Blog/2021/01/11/stuff-your-logs/>,
+//! with an incremental interface (via [`OwningIovec`]).
+//!
+//! Writers should only need the [`Encoder`].
+//!
+//! When the HCOBS-encoded bytes are embedded in a higher-level
+//! format, the [`Decoder`] is useful to decode one record at a time.
+//!
+//! However, HCOBS makes a lot of sense as the outermost framing; the
+//! [`StreamReader`] is ideal for that use-case (the write side can
+//! simply use an [`Encoder`]).  More complicated formats may require
+//! the direct use of a [`StreamChunker`], to find [`STUFF_SEQUENCE`]-
+//! delimited subsequences and pass (part of) the subsequences to a
+//! [`Decoder`].
+mod decoder;
+mod encoder;
+mod stream_reader;
+
+use std::io::Read;
+use std::num::NonZeroUsize;
+
+use decoder::DecoderState;
+use encoder::EncoderState;
+use owning_iovec::AnchoredSlice;
+use owning_iovec::ConsumingIovec;
+use owning_iovec::OwningIovec;
+
+pub use decoder::DecodingError;
+
+pub use stream_reader::Chunk;
+pub use stream_reader::StreamAction;
+pub use stream_reader::StreamChunker;
+pub use stream_reader::StreamReader;
+pub use stream_reader::DEFAULT_BLOCK_SIZE;
+
+/// The encoding radix for size headers in the hybrid byte stuffing scheme (253).
+pub const RADIX: usize = 0xfd;
+#[allow(clippy::assertions_on_constants)]
+const _: () = assert!(RADIX == 253);
+
+/// The forbidden (stuff) sentinel sequence that is removed by encoding
+/// and restored by decoding (`[0xFE, 0xFD]`).
+pub const STUFF_SEQUENCE: [u8; 2] = [0xfe, 0xfd];
+
+#[derive(Clone, Copy)]
+struct Parameters {
+    max_initial_size: NonZeroUsize,
+    max_subsequent_size: NonZeroUsize,
+}
+
+const PROD_PARAMS: Parameters = Parameters {
+    max_initial_size: unsafe { NonZeroUsize::new_unchecked(RADIX - 1) },
+    max_subsequent_size: unsafe { NonZeroUsize::new_unchecked((RADIX * RADIX) - 1) },
+};
+
+#[cfg(test)]
+const TEST_PARAMS: Parameters = Parameters {
+    max_initial_size: unsafe { NonZeroUsize::new_unchecked(3) },
+    max_subsequent_size: unsafe { NonZeroUsize::new_unchecked(5) },
+};
+
+/// Returns the index (for the first byte) for the first occurrence of
+/// [`STUFF_SEQUENCE`] in the input `bytes`, or `None` if the stuff
+/// sequence can't be found.
+#[must_use]
+#[inline(never)] // Keep out of line for profiling
+pub fn find_stuff_sequence(bytes: &[u8]) -> Option<usize> {
+    for (idx, window) in bytes.windows(2).enumerate() {
+        if window == STUFF_SEQUENCE {
+            return Some(idx);
+        }
+    }
+
+    None
+}
+
+/// Byte stuffs arbitrary inputs incrementally; slices that live
+/// as long the lifetime argument may be borrowed for encoding.
+///
+/// The encoder has a bounded amount of state, including the
+/// [`OwningIovec`], which also hangs on to a bounded amount of data
+/// that's not yet ready to be consumed: the HCOBS encoding scheme
+/// only needs to buffer at most 64 KB of data.
+///
+/// Of course, the [`OwningIovec`] will keep growing until the encoded
+/// bytes are consumed from it.
+#[derive(Debug)]
+pub struct Encoder<'this> {
+    state: EncoderState,
+    iovec: OwningIovec<'this>,
+}
+
+impl<'this> Default for Encoder<'this> {
+    #[inline(always)]
+    fn default() -> Self {
+        Encoder::new()
+    }
+}
+
+impl<'this> Encoder<'this> {
+    /// Returns a new encoder with a fresh [`OwningIovec`].
+    #[must_use]
+    pub fn new() -> Self {
+        Encoder::new_from_iovec(OwningIovec::new())
+    }
+
+    /// Returns a new encoder with a pre-existing [`OwningIovec`].
+    ///
+    /// Encoded bytes are appended after `iovec`'s current contents.
+    #[must_use]
+    pub fn new_from_iovec(mut iovec: OwningIovec<'this>) -> Self {
+        Encoder {
+            state: EncoderState::new(&mut iovec, PROD_PARAMS),
+            iovec,
+        }
+    }
+
+    /// Returns a consuming wrapper for the underlying [`OwningIovec`]
+    ///
+    /// Useful to consume incrementally from the output.
+    #[must_use]
+    #[inline(always)]
+    pub fn consumer(&mut self) -> ConsumingIovec<'_> {
+        self.iovec.consumer()
+    }
+
+    /// Appends `data` to the bytes to encode.
+    ///
+    /// This method tries to avoid copying large `data`.
+    pub fn encode(&mut self, data: &'this [u8]) {
+        let mut state = Default::default();
+        std::mem::swap(&mut state, &mut self.state);
+        self.state = state.encode_borrow(&mut self.iovec, PROD_PARAMS, data);
+    }
+
+    /// Appends `data` to the bytes to encode.
+    pub fn encode_copy(&mut self, data: &[u8]) {
+        let mut state = Default::default();
+        std::mem::swap(&mut state, &mut self.state);
+        self.state = state.encode_copy(&mut self.iovec, PROD_PARAMS, data);
+    }
+
+    /// Appends the bytes in `data` to the bytes to encode.
+    pub fn encode_anchored(&mut self, data: AnchoredSlice) {
+        let (_, slice, anchor) = unsafe { data.components() };
+
+        self.encode(slice);
+        self.iovec.push_anchor(anchor);
+    }
+
+    /// Flushes any pending encoding bytes and returns the underlying
+    /// [`OwningIovec`].
+    #[must_use]
+    pub fn finish(mut self) -> OwningIovec<'this> {
+        self.state.terminate(&mut self.iovec);
+        self.iovec
+    }
+
+    /// Reads up to `count` bytes from `reader` with up to `attempts` calls, and
+    /// ensures the result is allocated in the underlying [`owning_iovec::ByteArena`].
+    ///
+    /// The method retries up to `attempts` times to paper over
+    /// [`ErrorKind::Interrupted`] and short reads.
+    ///
+    /// EOF (0-sized reads) and non-[`ErrorKind::Interrupted`] error always stop the
+    /// the retries.
+    ///
+    /// If the retry loop managed to read at least one byte, that's considered a success
+    /// and returned to the caller.  Otherwise, returns the result of the last attempt
+    /// (an error or an empty slice on EOF).
+    ///
+    /// [`ErrorKind::Interrupted`]: [`std::io::ErrorKind::Interrupted`]
+    #[inline(always)]
+    pub fn read_n(
+        &mut self,
+        reader: impl Read,
+        count: usize,
+        attempts: NonZeroUsize,
+    ) -> std::io::Result<AnchoredSlice> {
+        let anchored_slice = self.iovec.arena().read_n(reader, count, attempts)?;
+        assert!(anchored_slice.slice().len() <= count);
+        Ok(anchored_slice)
+    }
+
+    /// Convenience wrapper around [`Self::read_n`] and [`Self::encode_anchored`].
+    ///
+    /// Reads up to `count` bytes from `reader` with up to `attempts` calls, then
+    /// encodes the bytes read.
+    ///
+    /// On success. returns the number of bytes read from `reader`.  Failure can
+    /// only happen during reading.
+    pub fn encode_read(
+        &mut self,
+        reader: impl Read,
+        count: usize,
+        attempts: NonZeroUsize,
+    ) -> std::io::Result<usize> {
+        let anchored_slice = self.read_n(reader, count, attempts)?;
+        let ret = anchored_slice.slice().len();
+
+        self.encode_anchored(anchored_slice);
+        Ok(ret)
+    }
+}
+
+/// Attempts to decode byte-stuffed data incrementally; slices that live
+/// as long the lifetime argument may be borrowed for decoding.
+///
+/// The encoder itself has a bounded amount of state, including the
+/// [`OwningIovec`].  Of course, the [`OwningIovec`] will keep growing
+/// until the encoded bytes are consumed from it.
+#[derive(Debug)]
+pub struct Decoder<'this> {
+    state: DecoderState,
+    iovec: OwningIovec<'this>,
+}
+
+impl<'this> Default for Decoder<'this> {
+    #[inline(always)]
+    fn default() -> Self {
+        Decoder::new()
+    }
+}
+
+impl<'this> Decoder<'this> {
+    /// Returns a new decoder with a fresh [`OwningIovec`].
+    #[must_use]
+    pub fn new() -> Self {
+        Decoder::new_from_iovec(OwningIovec::new())
+    }
+
+    /// Returns a new decoder with a pre-existing [`OwningIovec`].
+    ///
+    /// Decoded bytes are appended after `iovec`'s current contents.
+    #[must_use]
+    pub fn new_from_iovec(iovec: OwningIovec<'this>) -> Self {
+        Decoder {
+            state: DecoderState::new(),
+            iovec,
+        }
+    }
+
+    /// Returns a consumer for the underlying [`OwningIovec`].
+    ///
+    /// Useful to consume incrementally from the output.
+    #[must_use]
+    #[inline(always)]
+    pub fn consumer(&mut self) -> ConsumingIovec<'_> {
+        self.iovec.consumer()
+    }
+
+    /// Returns the internal [`OwningIovec`] with the remainder
+    /// of the bytes decoded so far.
+    #[must_use]
+    #[inline(always)]
+    pub fn take_iovec(self) -> OwningIovec<'this> {
+        self.iovec
+    }
+
+    /// Appends `data` to the bytes to decode.
+    ///
+    /// This methods tries to avoid copying large `data`.
+    pub fn decode(&mut self, data: &'this [u8]) -> Result<(), DecodingError> {
+        let mut state = Default::default();
+        std::mem::swap(&mut state, &mut self.state);
+        self.state = state.decode_borrow(&mut self.iovec, PROD_PARAMS, data)?;
+        Ok(())
+    }
+
+    /// Appends `data` to the bytes to decode.
+    pub fn decode_copy(&mut self, data: &[u8]) -> Result<(), DecodingError> {
+        let mut state = Default::default();
+        std::mem::swap(&mut state, &mut self.state);
+        self.state = state.decode_copy(&mut self.iovec, PROD_PARAMS, data)?;
+        Ok(())
+    }
+
+    /// Appends the contents of `data` to the bytes to decode.
+    pub fn decode_anchored(&mut self, data: AnchoredSlice) -> Result<(), DecodingError> {
+        let (_, slice, anchor) = unsafe { data.components() };
+
+        let ret = self.decode(slice);
+        self.iovec.push_anchor(anchor);
+        ret
+    }
+
+    /// Returns the underlying `OwningIovec`, if the input is complete and valid.
+    pub fn finish(self) -> Result<OwningIovec<'this>, DecodingError> {
+        self.state.terminate()?;
+        Ok(self.iovec)
+    }
+
+    /// Reads up to `count` bytes from `reader` with up to `attempts` calls, and
+    /// ensures the result is allocated in the underlying [`owning_iovec::ByteArena`].
+    ///
+    /// The method retries up to `attempts` times to paper over
+    /// [`ErrorKind::Interrupted`] and short reads.
+    ///
+    /// EOF (0-sized reads) and non-[`ErrorKind::Interrupted`] error always stop the
+    /// the retries.
+    ///
+    /// If the retry loop managed to read at least one byte, that's considered a success
+    /// and returned to the caller.  Otherwise, returns the result of the last attempt
+    /// (an error or an empty slice on EOF).
+    ///
+    /// [`ErrorKind::Interrupted`]: [`std::io::ErrorKind::Interrupted`]
+    #[inline(always)]
+    pub fn read_n(
+        &mut self,
+        reader: impl Read,
+        count: usize,
+        attempts: NonZeroUsize,
+    ) -> std::io::Result<AnchoredSlice> {
+        let anchored_slice = self.iovec.arena().read_n(reader, count, attempts)?;
+        assert!(anchored_slice.slice().len() <= count);
+        Ok(anchored_slice)
+    }
+
+    /// Convenience wrapper around [`Self::read_n`] and [`Self::decode_anchored`].
+    ///
+    /// Reads up to `count` bytes from `reader` with up to `attempts` calls, then
+    /// attempts to decode the bytes read.
+    ///
+    /// On success. returns the number of bytes read from `reader`.  Failure could
+    /// happen during reading or decoding (with `ErrorKind::other` for the latter).
+    pub fn decode_read(
+        &mut self,
+        reader: impl Read,
+        count: usize,
+        attempts: NonZeroUsize,
+    ) -> std::io::Result<usize> {
+        let anchored_slice = self.read_n(reader, count, attempts)?;
+
+        let len = anchored_slice.slice().len();
+        match self.decode_anchored(anchored_slice) {
+            Ok(()) => Ok(len),
+            Err(e) => Err(std::io::Error::other(e)),
+        }
+    }
+}
+
+#[cfg(test)]
+struct BadReader {
+    count: usize, // first invocation is successful.
+}
+
+#[cfg(test)]
+impl Read for BadReader {
+    fn read(&mut self, dst: &mut [u8]) -> std::io::Result<usize> {
+        self.count += 1;
+        match self.count {
+            1 => {
+                let mut reader = &b"7"[..];
+                reader.read(dst)
+            }
+            2 => Err(std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                "interrupted",
+            )),
+            3 => {
+                let mut reader = &b"89"[..];
+                reader.read(dst)
+            }
+            5 => {
+                let mut reader = &b""[..];
+                reader.read(dst)
+            }
+            _ => Err(std::io::Error::other("bad read")),
+        }
+    }
+}
+
+// Smoke test the public interface.
+#[test]
+fn smoke_test_miri() {
+    let mut encoder: Encoder<'_> = Default::default();
+
+    encoder.consumer().arena().ensure_capacity(10);
+    encoder.encode(b"123");
+    encoder.encode_copy(b"456");
+    assert!(encoder
+        .encode_read(BadReader { count: 10 }, 3, NonZeroUsize::new(1).unwrap())
+        .is_err()); // Bad read should no-op
+    assert_eq!(
+        encoder
+            .encode_read(BadReader { count: 10 }, 0, NonZeroUsize::new(1).unwrap())
+            .unwrap(),
+        0
+    ); // 0-sized reads succeed
+    assert_eq!(
+        encoder
+            .encode_read(BadReader { count: 4 }, 3, NonZeroUsize::new(1).unwrap())
+            .unwrap(),
+        0
+    ); // EOF read succeed
+    assert!(encoder
+        .encode_read(BadReader { count: 1 }, 3, NonZeroUsize::new(1).unwrap())
+        .is_err()); // EINTR fails
+    assert_eq!(
+        encoder
+            .encode_read(BadReader { count: 0 }, 4, NonZeroUsize::new(5).unwrap())
+            .expect("read must succeed"),
+        3
+    ); // handle short reads
+
+    assert_eq!(
+        encoder
+            .encode_read(BadReader { count: 0 }, 3, NonZeroUsize::new(5).unwrap())
+            .expect("read must succeed"),
+        3
+    ); // exact reads also work
+
+    let iovec = encoder.finish();
+    assert_eq!(
+        iovec.flatten().expect("no backpatch left"),
+        b"\x0c123456789789"
+    );
+
+    // decode
+    {
+        let mut decoder: Decoder<'_> = Default::default();
+        for slice in iovec.into_iter() {
+            decoder.decode(slice).expect("success");
+        }
+
+        // Can peek
+        assert_eq!(
+            decoder.consumer().flatten().expect("no backpatch left"),
+            b"123456789789"
+        );
+
+        // Termination succeeds
+        let output = decoder.finish().expect("success");
+        assert_eq!(
+            output.flatten().expect("no backpatch left"),
+            b"123456789789"
+        );
+    }
+
+    // decode copy
+    {
+        let mut decoder: Decoder<'_> = Default::default();
+        for slice in iovec.into_iter() {
+            decoder.decode_copy(slice).expect("success");
+        }
+
+        assert_eq!(
+            decoder.consumer().flatten().expect("no backpatch left"),
+            b"123456789789"
+        );
+
+        let output = decoder.finish().expect("success");
+        assert_eq!(
+            output.flatten().expect("no backpatch left"),
+            b"123456789789"
+        );
+    }
+
+    // decode read
+    {
+        let mut decoder: Decoder<'_> = Default::default();
+
+        // Bad read should no-op
+        assert!(decoder
+            .decode_read(BadReader { count: 10 }, 3, NonZeroUsize::new(1).unwrap())
+            .is_err());
+
+        for slice in iovec.into_iter() {
+            let slice: &[u8] = slice;
+            decoder
+                .decode_read(slice, slice.len(), NonZeroUsize::new(1).unwrap())
+                .expect("success");
+        }
+
+        assert_eq!(
+            decoder.consumer().flatten().expect("no backpatch left"),
+            b"123456789789"
+        );
+
+        let output = decoder.finish().expect("success");
+        assert_eq!(
+            output.flatten().expect("no backpatch left"),
+            b"123456789789"
+        );
+    }
+}
+
+// make sure we can consume incrementally with the prod interface.
+#[test]
+fn prod_peek() {
+    let mut encoder: Encoder<'_> = Default::default();
+
+    // The initial cache is 4KB, write that much.
+    for _ in 0..1024 {
+        encoder.encode(b"\x00\x00\x00\x00");
+    }
+
+    // Force the chunk to end.
+    encoder.encode(b"\xFE\xFD");
+
+    let header: &[u8] = b"\xfc";
+    let zeros = vec![0u8; 4000];
+    let second_header: &[u8] = b"\x31\x0f";
+    // 252 zeros, then 4096 - 252 = 3844 zeros.
+    let expected = [header, &zeros[..252], second_header, &zeros[..3844]].concat();
+
+    assert_eq!(encoder.consumer().stable_prefix().len(), 1);
+
+    assert_eq!(
+        &encoder
+            .consumer()
+            .stable_prefix()
+            .iter()
+            .flat_map(|x| -> &[u8] { x })
+            .copied()
+            .collect::<Vec<u8>>(),
+        // Only 4095 because the last 4-byte write goes directly to the
+        // next arena chunk instead of spltting.
+        &expected[0..4095]
+    );
+
+    assert_eq!(encoder.consumer().consume(1), 1);
+
+    let iovec = encoder.finish();
+    assert_eq!(
+        iovec.flatten().expect("no backpatch left"),
+        [
+            0, 0, 0, 0, // final 4-byte write
+            0, 0
+        ] // terminator
+    );
+}
+
+// Exercise error handling in decoding.
+#[test]
+fn prod_decode_bad_miri() {
+    {
+        let mut decoder: Decoder<'_> = Default::default();
+
+        // Bad data.
+        assert!(decoder.decode(b"\xff").is_err());
+    }
+
+    {
+        let mut decoder: Decoder<'_> = Default::default();
+
+        // Same, with decode_copy
+        assert!(decoder.decode_copy(b"\xff").is_err());
+    }
+
+    {
+        let mut decoder: Decoder<'_> = Default::default();
+
+        // Truncated chunk
+        decoder.decode(b"\xfc").expect("ok");
+        decoder.decode_copy(&vec![0u8; 253]).expect("ok");
+
+        // Missing the next chunk.
+        assert!(decoder.finish().is_err());
+    }
+}
+
+#[cfg(test)]
+fn prod_encode_streaming(repeat: usize) {
+    assert_eq!(owning_iovec::ByteArena::num_live_chunks(), 0);
+    assert_eq!(owning_iovec::ByteArena::num_live_bytes(), 0);
+
+    let mut encoder: Encoder<'_> = Default::default();
+    let payload = [1u8; 1000];
+
+    for _ in 0..repeat {
+        encoder.encode_copy(&payload);
+        let consumer = encoder.consumer();
+        let prefix = consumer.stable_prefix();
+        if !prefix.is_empty() {
+            let len = prefix.len();
+            assert_eq!(encoder.consumer().consume(len), len);
+        }
+    }
+
+    assert!(owning_iovec::ByteArena::num_live_chunks() <= 2);
+    assert!(owning_iovec::ByteArena::num_live_bytes() <= 2 * 1024 * 1024);
+
+    std::mem::drop(encoder);
+
+    assert_eq!(owning_iovec::ByteArena::num_live_chunks(), 0);
+    assert_eq!(owning_iovec::ByteArena::num_live_bytes(), 0);
+}
+
+#[cfg(miri)]
+#[test]
+fn prod_encode_streaming_slow() {
+    prod_encode_streaming(400);
+}
+
+#[cfg(test)]
+fn prod_decode_streaming(repeat: usize) {
+    assert_eq!(owning_iovec::ByteArena::num_live_chunks(), 0);
+    assert_eq!(owning_iovec::ByteArena::num_live_bytes(), 0);
+
+    let mut decoded_size = 0usize;
+    let payload = [1u8; 1000];
+    let mut encoder: Encoder<'_> = Default::default();
+
+    let mut decoder: Decoder<'_> = Default::default();
+
+    for _ in 0..repeat {
+        encoder.encode(&payload);
+        let mut consumer = encoder.consumer();
+        let prefix = consumer.stable_prefix();
+        for slice in prefix {
+            decoder.decode_copy(slice).expect("ok");
+        }
+
+        let len = prefix.len();
+        assert_eq!(consumer.consume(prefix.len()), len);
+
+        let mut consumer = decoder.consumer();
+        let prefix = consumer.stable_prefix();
+        for slice in prefix {
+            let slice: &[u8] = slice;
+            decoded_size += slice.len();
+            for byte in slice {
+                assert_eq!(*byte, 1u8);
+            }
+        }
+
+        let len = prefix.len();
+        assert_eq!(consumer.consume(prefix.len()), len);
+    }
+
+    assert!(owning_iovec::ByteArena::num_live_chunks() <= 3);
+    assert!(owning_iovec::ByteArena::num_live_bytes() <= 3 * 1024 * 1024);
+
+    let tail = encoder.finish().flatten().expect("no backpatch left");
+    decoder.decode_copy(&tail).expect("valid");
+
+    assert!(owning_iovec::ByteArena::num_live_chunks() <= 2);
+    assert!(owning_iovec::ByteArena::num_live_bytes() <= 2 * 1024 * 1024);
+
+    let decoded_tail = decoder.finish().unwrap().flatten().unwrap();
+    decoded_size += decoded_tail.len();
+    for byte in decoded_tail {
+        assert_eq!(byte, 1u8);
+    }
+
+    assert_eq!(decoded_size, repeat * payload.len());
+
+    assert_eq!(owning_iovec::ByteArena::num_live_chunks(), 0);
+    assert_eq!(owning_iovec::ByteArena::num_live_bytes(), 0);
+}
+
+#[cfg(miri)]
+#[test]
+fn prod_decode_streaming_slow() {
+    prod_decode_streaming(400);
+}
+
+#[cfg(all(test, not(miri)))]
+use rusty_fork::rusty_fork_test;
+
+#[cfg(all(test, not(miri)))]
+rusty_fork_test! {
+    #[test]
+    fn prod_encode_streaming_fork() {
+        prod_encode_streaming(10000);
+    }
+
+    #[test]
+    fn prod_decode_streaming_fork() {
+        prod_decode_streaming(10000);
+    }
+}

--- a/hcobs/src/stream_reader.rs
+++ b/hcobs/src/stream_reader.rs
@@ -1,0 +1,590 @@
+//! The `stream_reader` module wraps the low-level [`crate::Decoder`]
+//! to read [`STUFF_SEQUENCE`]-delimited HCOBS-encoded records on the
+//! fly from a stream of bytes.
+use std::io::Result;
+use std::num::NonZeroUsize;
+use std::ops::Range;
+
+use super::Decoder;
+use super::STUFF_SEQUENCE;
+use owning_iovec::AnchoredSlice;
+use owning_iovec::ByteArena;
+use owning_iovec::ConsumingIovec;
+use owning_iovec::OwningIovec;
+
+/// Default IO block size (512 KB).
+pub const DEFAULT_BLOCK_SIZE: usize = 512 * 1024;
+
+#[cfg(test)]
+const TEST_BLOCK_SIZE: Option<usize> = Some(3);
+
+/// A [`StreamReader`] buffers reads from [`std::io::Read`]s and
+/// yields the decoded contents of valid HCOBS-encoded records,
+/// assuming [`STUFF_SEQUENCE`] separators.
+#[derive(Clone, Debug, Default)]
+pub struct StreamReader {
+    iovec: OwningIovec<'static>,
+    chunker: StreamChunker,
+    // Offset of the (first byte of the) last STUFF_SEQUENCE sentinel in `chunker`.
+    last_sentinel_offset: u64,
+}
+
+/// The [`StreamReader`] periodically invokes a function to determine
+/// what to do with the current HCOBS-encoded record.  This enum describes
+/// the potential actions.
+#[must_use]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum StreamAction {
+    /// Keep decoding the record
+    KeepGoing,
+    /// Skip to the next record
+    SkipRecord,
+    /// Stop with EOF right away
+    Stop,
+}
+
+/// The [`StreamChunker`] reads a stream of bytes from a
+/// [`std::io::Read`] and yields a sequence of [`Chunk`]s that fully
+/// describe the input stream (i.e., the [`StreamChunker`] segments
+/// the input stream into a stream of [`Chunk`]s).
+#[derive(Clone, Debug, Default)]
+pub struct StreamChunker {
+    buf: AnchoredSlice,
+    offset: u64,
+}
+
+/// A [`Chunk`] describes a subsequence of an input stream.
+#[derive(Clone, Debug)]
+pub enum Chunk {
+    /// A [`STUFF_SEQUENCE`] sentinel that ends at the `u64` byte
+    /// offset in the input stream.
+    Sentinel(u64),
+    /// End of stream.
+    Eof,
+    /// A slice of bytes that ends at the `u64` byte offset in the
+    /// input stream.  The slice does not contain a [`STUFF_SEQUENCE`]
+    /// nor will two adjacent `Data` chunks split a [`STUFF_SEQUENCE`]
+    /// between their first and last bytes.
+    Data((u64, AnchoredSlice)),
+}
+
+impl StreamChunker {
+    /// Pumps the nect segment from the input stream.
+    ///
+    /// When the [`StreamChunker`] needs to read more data,
+    /// it uses the `reader`, and attempts to read blocks of
+    /// `io_block_size` bytes.
+    pub fn pump(
+        &mut self,
+        arena: &mut ByteArena,
+        mut reader: impl std::io::Read,
+        io_block_size: usize,
+    ) -> Result<Chunk> {
+        use std::io::Read;
+        // Can't do 0-byte I/O
+        let io_block_size = io_block_size.max(1);
+        while self.buf.slice().len() < 2 {
+            let buf = self.buf.take();
+
+            let initial_length = buf.slice().len();
+            let mut slice = buf.slice();
+            let concat = (&mut slice).chain(&mut reader);
+
+            let buf = arena.read_n(concat, io_block_size, NonZeroUsize::MAX)?;
+            if buf.slice().len() == initial_length {
+                // No progress, must be Eof.
+                if buf.slice().is_empty() {
+                    return Ok(Chunk::Eof);
+                } else {
+                    self.offset += buf.slice().len() as u64;
+                    return Ok(Chunk::Data((self.offset, buf)));
+                }
+            }
+
+            self.buf = buf;
+        }
+
+        assert!(self.buf.slice().len() >= 2);
+
+        if self.buf.slice()[0..2] == STUFF_SEQUENCE {
+            self.offset += 2;
+            self.buf.skip_prefix(2);
+            return Ok(Chunk::Sentinel(self.offset));
+        }
+
+        let split_pos = if let Some(idx) = super::find_stuff_sequence(self.buf.slice()) {
+            // Split at the stuff sequence if we have one.
+            idx
+        } else if *self.buf.slice().last().unwrap() == STUFF_SEQUENCE[0] {
+            // Split just before the last byte if it could be part of a stuff sequence
+            self.buf.slice().len() - 1
+        } else {
+            // otherwise, take the whole slice.
+            self.buf.slice().len()
+        };
+
+        // We already checked for that case.
+        assert_ne!(split_pos, 0);
+
+        let prefix;
+        (prefix, self.buf) = self.buf.take().split_at(split_pos);
+
+        self.offset += prefix.slice().len() as u64;
+        Ok(Chunk::Data((self.offset, prefix)))
+    }
+}
+
+impl StreamReader {
+    /// Returns a fresh default-constructed [`StreamReader`]
+    #[must_use]
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Returns a judge function for HCOBS-encoded records.
+    ///
+    /// Records whose size exceeds `max_record_size` are skipped, and
+    /// decoding stops when we see [`STUFF_SEQUENCE`] delimiter for a new
+    /// record that would start at or after `limit_offset` in the encoded
+    /// bytes.
+    pub fn chunk_judge(
+        max_record_size: usize,
+        limit_offset: Option<u64>,
+    ) -> impl Fn(Range<u64>, ConsumingIovec<'_>) -> StreamAction {
+        let limit_offset = limit_offset.unwrap_or(u64::MAX);
+
+        move |range, iovec| {
+            if range.start >= limit_offset {
+                StreamAction::Stop
+            } else if iovec.total_size() > max_record_size {
+                StreamAction::SkipRecord
+            } else {
+                StreamAction::KeepGoing
+            }
+        }
+    }
+
+    /// Returns the offset (in terms of bytes pulled from a reader)
+    /// for the first byte of the most recently read (highest offset)
+    /// stuff sequence sentinel.
+    #[must_use]
+    #[inline(always)]
+    pub fn last_sentinel_offset(&self) -> u64 {
+        self.last_sentinel_offset
+    }
+
+    /// Attempts to decode the next [`STUFF_SEQUENCE`] delimited record
+    /// from `reader`.
+    ///
+    /// When more data is needed, this method attempts to read from
+    /// `reader` in `io_block_size` (or [`DEFAULT_BLOCK_SIZE`] blocks.
+    ///
+    /// Calls the `record_judge` with the current byte range in the
+    /// stuffed input for the record the bytes decoded so far in order
+    /// to know what to do: keep attempting to decode the record, skip
+    /// the record, or stop reading (i.e., EOF).
+    ///
+    /// Returns an IO error if `reader` does, and None on EOF.  Otherwise,
+    /// returns a pair of:
+    ///  - an [`OwningIovec`] filled with the decoded record's contents
+    ///  - the range of encoded bytes read to yield this record
+    ///
+    /// Invalid HCOBS byte sequence are silently skipped (but still passed
+    /// to the `record_judge` for early exit).
+    pub fn next_record_bytes(
+        &mut self,
+        mut reader: impl std::io::Read,
+        mut record_judge: impl FnMut(Range<u64>, ConsumingIovec<'_>) -> StreamAction,
+        io_block_size: Option<usize>,
+    ) -> Result<Option<(&mut OwningIovec<'static>, Range<u64>)>> {
+        #[derive(PartialEq, Eq)]
+        enum State {
+            // We start here, until we hit a non-STUFF_SEQUENCE byte
+            SkipSentinel,
+            // Then keep decoding...
+            DecodeRecord,
+            // Until we hit an invalid encoded sequence, or the judge
+            // tells us to skip.
+            SkipRecord,
+        }
+
+        let io_block_size = io_block_size.unwrap_or(DEFAULT_BLOCK_SIZE);
+
+        'retry: loop {
+            self.iovec.clear();
+            let mut decoder = Decoder::new_from_iovec(self.iovec.take());
+
+            let mut state = State::SkipSentinel;
+            let mut range = 0u64..0u64;
+            loop {
+                assert_eq!(range.is_empty(), state == State::SkipSentinel);
+
+                match self
+                    .chunker
+                    .pump(decoder.consumer().arena(), &mut reader, io_block_size)?
+                {
+                    Chunk::Sentinel(offset) => {
+                        // The offset is the end byte.
+                        assert!(offset >= 2);
+                        self.last_sentinel_offset = offset - (STUFF_SEQUENCE.len() as u64);
+                        match state {
+                            State::SkipSentinel => range = offset..offset,
+                            // We hit a sentinel, so the record is complete.
+                            State::DecodeRecord | State::SkipRecord => break,
+                        }
+                    }
+                    Chunk::Eof => {
+                        // We hit EOF and didn't find any data chunk.  Bail.
+                        if range.is_empty() {
+                            return Ok(None);
+                        }
+
+                        break;
+                    }
+                    Chunk::Data((offset, slice)) => {
+                        // data slices are non-empty.
+                        assert!(!slice.slice().is_empty());
+
+                        match state {
+                            // We were in SkipSentinel state, so this is a new record.
+                            State::SkipSentinel => {
+                                let start = offset - (slice.slice().len() as u64);
+                                range = start..start;
+                                state = State::DecodeRecord
+                            }
+                            State::DecodeRecord => {}
+                            // Don't `continue`: let the judge have at it and decide if it's
+                            // time to just stop decoding.
+                            State::SkipRecord => {}
+                        }
+
+                        // Try to decode if we should
+                        if state == State::DecodeRecord && decoder.decode_anchored(slice).is_err() {
+                            // And skip the rest of the record if it's invalid.
+                            state = State::SkipRecord;
+                        }
+
+                        range.end = offset;
+                    }
+                }
+
+                match record_judge(range.clone(), decoder.consumer()) {
+                    StreamAction::KeepGoing => {}
+                    StreamAction::SkipRecord => state = State::SkipRecord,
+                    StreamAction::Stop => return Ok(None),
+                }
+            }
+
+            // We only get here from a DecodeRecord state (or EOF and range non-empty)
+            assert_ne!(&range.start, &range.end);
+
+            if state == State::SkipRecord {
+                self.iovec = decoder.take_iovec();
+                continue 'retry;
+            }
+
+            let Ok(iovec) = decoder.finish() else {
+                continue 'retry;
+            };
+
+            self.iovec = iovec;
+            return Ok(Some((&mut self.iovec, range)));
+        }
+    }
+}
+
+// Check that we can read a couple HCOBS records.
+#[test]
+fn test_stream_reader_miri() {
+    let payload: &[&[u8]] = &[
+        b"\x01a", // Missing stuff sequence here
+        &STUFF_SEQUENCE,
+        b"\x02bc",
+        &STUFF_SEQUENCE,
+        &STUFF_SEQUENCE,
+        b"\x03def",
+        &STUFF_SEQUENCE,
+        &STUFF_SEQUENCE, // extra stuff sequence
+        &STUFF_SEQUENCE,
+        b"\x03ghijk", // invalid
+        &STUFF_SEQUENCE,
+        b"\xffghijk", // invalid
+        &STUFF_SEQUENCE,
+        &STUFF_SEQUENCE,
+        b"\x071234567", // too long
+        &STUFF_SEQUENCE,
+        &STUFF_SEQUENCE,
+        b"\x01z",
+        // missing stuff sequence here
+    ];
+    let judge = StreamReader::chunk_judge(4, None);
+    let mut payload = &payload.concat()[..];
+
+    let mut reader = StreamReader::new();
+    let (iovec, pos) = reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .expect("must have data");
+    assert_eq!(pos, 0..2);
+
+    assert_eq!(iovec.flatten().expect("no backpatch"), b"a");
+
+    let (iovec, pos) = reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .expect("must have data");
+    assert_eq!(pos, 4..7);
+
+    assert_eq!(iovec.flatten().expect("no backpatch"), b"bc");
+
+    let (iovec, pos) = reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .expect("must have data");
+    assert_eq!(pos, 11..15);
+
+    assert_eq!(
+        iovec
+            .stable_prefix()
+            .iter()
+            .flat_map(|x| -> &[u8] { x })
+            .copied()
+            .collect::<Vec<u8>>(),
+        b"def"
+    );
+
+    let (iovec, pos) = reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .expect("must have data");
+    assert_eq!(pos, 51..53);
+
+    assert_eq!(iovec.flatten().expect("no backpatch"), b"z");
+
+    // Last record was at 51..53, so the sentinel just before was at 49.
+    assert_eq!(reader.last_sentinel_offset(), 49);
+
+    // Should hit EOF
+    assert!(reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .is_none());
+    // And stay there
+    assert!(reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .is_none());
+}
+
+// Confirm that we can stop reading after an offset.
+#[test]
+fn test_stream_reader_partial_miri() {
+    let contents: &[&[u8]] = &[b"\x01a", &STUFF_SEQUENCE, b"\x02bc"];
+    let mut payload = &contents.concat()[..];
+
+    let judge = StreamReader::chunk_judge(usize::MAX, None);
+    let mut reader = StreamReader::new();
+    let (iovec, pos) = reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .expect("must have data");
+    assert_eq!(pos, 0..2);
+    assert_eq!(iovec.flatten().expect("no backpatch"), b"a");
+    let (iovec, pos) = reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .expect("must have data");
+    assert_eq!(pos, 4..7);
+
+    assert_eq!(iovec.flatten().expect("no backpatch"), b"bc");
+
+    // Should hit EOF
+    assert!(reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .is_none());
+
+    // Now do the same thing, but stop after byte 1.
+    let judge = StreamReader::chunk_judge(usize::MAX, Some(1u64));
+    let mut payload = &contents.concat()[..];
+    let mut reader = StreamReader::new();
+    let (iovec, pos) = reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .expect("must have data");
+    assert_eq!(pos, 0..2);
+    assert_eq!(iovec.flatten().expect("no batckpatch"), b"a");
+
+    // Should immediately hit EOF
+    assert!(reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .is_none());
+
+    // Stop after byte 1, on a stuff sequence.
+    let contents: &[&[u8]] = &[b"\x01a", &STUFF_SEQUENCE, &STUFF_SEQUENCE, b"\x02bc"];
+
+    let judge = StreamReader::chunk_judge(usize::MAX, Some(1u64));
+    let mut payload = &contents.concat()[..];
+    let mut reader = StreamReader::new();
+    let (iovec, pos) = reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .expect("must have data");
+    assert_eq!(pos, 0..2);
+    assert_eq!(iovec.flatten().expect("no backpatch"), b"a");
+
+    // Should immediately hit EOF
+    assert!(reader
+        .next_record_bytes(&mut payload, &judge, TEST_BLOCK_SIZE)
+        .expect("must succeed")
+        .is_none());
+}
+
+// Empty file should direct return EOF
+#[test]
+fn test_stream_reader_empty_miri() {
+    let mut payload: &[u8] = &[];
+
+    let mut reader = StreamReader::new();
+    assert!(reader
+        .next_record_bytes(
+            &mut payload,
+            StreamReader::chunk_judge(usize::MAX, None),
+            TEST_BLOCK_SIZE
+        )
+        .expect("must succeed")
+        .is_none());
+}
+
+// Only a stuff sequence -> return EOF
+#[test]
+fn test_stream_reader_stuff_only_miri() {
+    let mut payload = &STUFF_SEQUENCE[..];
+
+    let mut reader = StreamReader::new();
+    assert!(reader
+        .next_record_bytes(
+            &mut payload,
+            StreamReader::chunk_judge(usize::MAX, None),
+            TEST_BLOCK_SIZE
+        )
+        .expect("must succeed")
+        .is_none());
+}
+
+// Couple stuff sequence -> data, should decode fine.
+#[test]
+fn test_stream_reader_many_stuff_miri() {
+    let payload: &[&[u8]] = &[&STUFF_SEQUENCE, &STUFF_SEQUENCE, b"\x00"];
+
+    let mut payload = &payload.concat()[..];
+    let mut reader = StreamReader::new();
+    let (iovec, pos) = reader
+        .next_record_bytes(
+            &mut payload,
+            StreamReader::chunk_judge(usize::MAX, None),
+            TEST_BLOCK_SIZE,
+        )
+        .expect("must succeed")
+        .expect("must have data");
+
+    let slices = iovec.stable_prefix();
+    assert_eq!(slices.len(), 0);
+    assert_eq!(pos, 4..5);
+}
+
+// Only one message should decode fine.
+#[test]
+fn test_stream_reader_one_message_miri() {
+    let mut payload = &b"\x01a"[..];
+
+    let mut reader = StreamReader::new();
+
+    let (iovec, pos) = reader
+        .next_record_bytes(
+            &mut payload,
+            StreamReader::chunk_judge(usize::MAX, None),
+            TEST_BLOCK_SIZE,
+        )
+        .expect("must succeed")
+        .expect("must have data");
+    assert_eq!(pos, 0..2);
+
+    assert_eq!(iovec.flatten().expect("no backpatch"), b"a");
+
+    assert!(reader
+        .next_record_bytes(
+            &mut payload,
+            StreamReader::chunk_judge(usize::MAX, None),
+            TEST_BLOCK_SIZE
+        )
+        .expect("must succeed")
+        .is_none());
+}
+
+// Rruncated messages should be skipped.
+#[test]
+fn test_stream_reader_truncated_message_miri() {
+    // Two truncated messages, one terminated by a stuff sequence,
+    // another by EOF.
+    let mut payload = &b"\x02a\xFE\xFD\x05b"[..];
+
+    let mut reader = StreamReader::new();
+
+    assert!(reader
+        .next_record_bytes(
+            &mut payload,
+            StreamReader::chunk_judge(usize::MAX, None),
+            TEST_BLOCK_SIZE
+        )
+        .expect("must succeed")
+        .is_none());
+}
+
+// We should gracefully bubble up an error in the middle of a
+// record.
+#[test]
+fn test_stream_reader_error_miri() {
+    struct Reader {
+        payload: &'static [u8],
+    }
+
+    impl std::io::Read for Reader {
+        fn read(&mut self, dst: &mut [u8]) -> Result<usize> {
+            if self.payload.is_empty() {
+                Err(std::io::Error::other("bad"))
+            } else {
+                let to_read = self.payload.len().min(dst.len());
+                dst[..to_read].copy_from_slice(&self.payload[..to_read]);
+                self.payload = &self.payload[to_read..];
+                Ok(to_read)
+            }
+        }
+    }
+
+    let mut payload = Reader {
+        payload: b"\x01a\xFE\xFD\x00",
+    };
+
+    let mut reader = StreamReader::new();
+
+    let (iovec, pos) = reader
+        .next_record_bytes(
+            &mut payload,
+            StreamReader::chunk_judge(usize::MAX, None),
+            TEST_BLOCK_SIZE,
+        )
+        .expect("must succeed")
+        .expect("must have data");
+    assert_eq!(pos, 0..2);
+    assert_eq!(iovec.flatten().expect("no backpatch"), b"a");
+
+    assert!(reader
+        .next_record_bytes(
+            &mut payload,
+            StreamReader::chunk_judge(usize::MAX, None),
+            TEST_BLOCK_SIZE
+        )
+        .is_err());
+}

--- a/owning_iovec/Cargo.toml
+++ b/owning_iovec/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "owning_iovec"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+sliding_deque = { path = "../sliding_deque" }
+smallvec = "1"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"  # for `struct iovec`
+
+[lints]
+workspace = true

--- a/owning_iovec/src/byte_arena/alloc_cache.rs
+++ b/owning_iovec/src/byte_arena/alloc_cache.rs
@@ -1,0 +1,206 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
+use std::io::IoSlice;
+use std::mem::MaybeUninit;
+use std::ops::Range;
+use std::sync::Arc;
+
+use super::anchor::Anchor;
+use super::anchor::Chunk;
+use super::ioslice;
+
+/// An [`AllocCache`] is a bump pointer in a range of pre-allocated
+/// [`MaybeUninit<u8>`].
+///
+/// Whenever `AllocCache` returns a slice, it also ensures an
+/// [`Anchor`] is responsible for keeping the slice's backing memory
+/// alive.
+#[derive(Debug)]
+pub struct AllocCache {
+    bump: *mut MaybeUninit<u8>,
+    range: Range<*mut MaybeUninit<u8>>, // XXX: redundant with `backing`.
+    backing: Arc<Chunk>,                // Backing memory for `AllocCache`.
+}
+
+// AllocCache is thread-compatible
+unsafe impl Send for AllocCache {}
+unsafe impl Sync for AllocCache {}
+
+impl AllocCache {
+    /// Returns a fresh [`AllocCAche`] that has capacity at least equal to `wanted`,
+    /// and equal to `hint` if possible.
+    #[must_use]
+    pub fn new(wanted: usize, hint: usize) -> AllocCache {
+        let capacity = hint.max(wanted);
+        assert!(capacity >= wanted);
+        let mut storage = Vec::<MaybeUninit<u8>>::with_capacity(capacity);
+        // SAFETY: MaybeUninit is always "initialised"
+        unsafe { storage.set_len(capacity) };
+        let mut chunk = Chunk::new(storage.into_boxed_slice());
+        let range = chunk.as_mut_ptr_range();
+
+        AllocCache {
+            bump: range.start,
+            range,
+            backing: Arc::new(chunk),
+        }
+    }
+
+    /// Returns the initial capacity allocated for the backing chunk
+    /// (i.e., the size of the backing chunk).
+    #[must_use]
+    #[inline(always)]
+    pub fn initial_size(&self) -> usize {
+        (self.range.end as usize) - (self.range.start as usize)
+    }
+
+    /// Returns the address range for the backing chunk.
+    #[must_use]
+    #[inline(always)]
+    pub fn range(&self) -> Range<usize> {
+        Range {
+            start: self.range.start as usize,
+            end: self.range.end as usize,
+        }
+    }
+
+    /// Returns the address of the next allocationn (one past the
+    /// end of the most recent allocation).
+    #[must_use]
+    #[inline(always)]
+    pub fn next_alloc_address(&self) -> usize {
+        self.bump as usize
+    }
+
+    /// Returns the amount of space remaining in the backing chunk.
+    #[must_use]
+    #[inline(always)]
+    pub fn remaining(&self) -> usize {
+        assert!(self.range.start <= self.bump);
+        assert!(self.bump <= self.range.end);
+        let bump = self.bump as usize;
+        let end = self.range.end as usize;
+
+        assert!(bump <= end);
+        end - bump
+    }
+
+    /// Allocates `wanted > 0` bytes and either makes `old_anchor`
+    /// hold onto the returned slice's backing memory, or returns
+    /// a fresh [`Anchor`].
+    ///
+    /// The caller *must* ensure `self.remaining() >= wanted` before
+    /// calling this method.
+    ///
+    /// The `'static` lifetime on the slice is a lie; it lives as
+    /// long as either `old_anchor`, or `anchor`.
+    #[must_use]
+    #[inline(always)]
+    pub unsafe fn alloc_or_die(
+        &mut self,
+        wanted: usize,
+        old_anchor: Option<&mut Anchor>,
+    ) -> (IoSlice<'static>, Option<Anchor>) {
+        assert!(self.range.start <= self.bump);
+        assert!(self.bump <= self.range.end);
+
+        let bump = self.bump as usize;
+        let end = self.range.end as usize;
+        assert!(end - bump >= wanted);
+
+        // SAFETY: bump + wanted <= end
+        let ret = ioslice::make_ioslice(self.bump as *mut u8, wanted);
+        self.bump = unsafe { self.bump.add(wanted) };
+
+        // Avoid cloning `self.backing` if possible.
+        let anchor = Anchor::merge_ref_or_create(old_anchor, &self.backing);
+        (ret, anchor)
+    }
+
+    /// Marks the bytes in `remainder` as available for new allocations.
+    ///
+    /// This `remainder` slice must come from allocation cache and stop
+    /// right at the current bump pointer.
+    pub fn release_or_die(&mut self, remainder: IoSlice<'_>) {
+        let (base, len) = ioslice::ioslice_components(remainder);
+        let addr = base as usize;
+        let end_addr = addr + len;
+
+        // The start address must be strictly in the backing chunk, unless
+        // we have an empty remainder (at the tail of the chunk).
+        assert!(self.range().contains(&addr) | remainder.is_empty());
+        assert_eq!(self.bump as usize, end_addr);
+
+        // SAFETY: `remainder` is fully in the backing chunk.
+        self.bump = unsafe { self.bump.sub(len) };
+    }
+}
+
+#[test]
+fn test_new_miri() {
+    let cache = AllocCache::new(10, 20);
+    assert_eq!(cache.initial_size(), 20);
+    assert_eq!(cache.remaining(), 20);
+}
+
+#[test]
+fn test_alloc_or_die_miri() {
+    let mut cache = AllocCache::new(10, 20);
+    let (slice, anchor) = unsafe { cache.alloc_or_die(5, None) };
+    assert_eq!(slice.len(), 5);
+    assert!(anchor.is_some());
+    assert_eq!(cache.remaining(), 15);
+}
+
+#[test]
+fn test_release_or_die_miri() {
+    let mut cache = AllocCache::new(10, 20);
+    let (slice, _anchor) = unsafe { cache.alloc_or_die(5, None) };
+    cache.release_or_die(slice);
+    assert_eq!(cache.remaining(), 20);
+}
+
+#[test]
+fn test_release_or_die_empty_miri() {
+    let mut cache = AllocCache::new(20, 20);
+    let (slice, _anchor) = unsafe { cache.alloc_or_die(20, None) };
+    cache.release_or_die(IoSlice::new(&slice[20..]));
+    assert_eq!(cache.remaining(), 0);
+}
+
+#[test]
+fn test_alloc_and_release_miri() {
+    let mut cache = AllocCache::new(10, 20);
+    let (slice1, anchor1) = unsafe { cache.alloc_or_die(5, None) };
+    let (slice2, _anchor2) = unsafe { cache.alloc_or_die(10, Some(&mut anchor1.unwrap())) };
+    assert_eq!(slice1.len(), 5);
+    assert_eq!(slice2.len(), 10);
+    assert_eq!(cache.remaining(), 5);
+    cache.release_or_die(slice2);
+    assert_eq!(cache.remaining(), 15);
+}
+
+#[test]
+#[should_panic(expected = "end - bump >= wanted")]
+fn test_alloc_too_large_miri() {
+    let mut cache = AllocCache::new(10, 20);
+    let _result = unsafe { cache.alloc_or_die(21, None) };
+}
+
+#[test]
+#[should_panic(expected = "assertion failed")]
+fn test_release_invalid_slice_miri() {
+    let mut cache = AllocCache::new(10, 20);
+    let mut vec = Vec::with_capacity(5);
+
+    // Assume init to make clippy happy. Hopefully MIRI
+    // can still see that it wasn't actually initialised:
+    // we shouldn't read from the bad slice.
+    for slot in vec.spare_capacity_mut() {
+        unsafe { slot.assume_init_mut() };
+    }
+    unsafe { vec.set_len(5) };
+
+    let slice = IoSlice::new(&vec);
+    cache.release_or_die(slice);
+}

--- a/owning_iovec/src/byte_arena/anchor.rs
+++ b/owning_iovec/src/byte_arena/anchor.rs
@@ -1,0 +1,156 @@
+//! Allocations in a `ByteArena` consist of `u8` slices kept alive by an [`Anchor`].
+//! Each anchor contains an [`Arc<Chunk>`], which keeps a backing allocation
+//! alive.  One [`Arc`] per allocation would be wasteful, so each [`Anchor`]
+//! may be responsible for any number of slices.
+//!
+//! The relationship between slices and [`Anchor`]s is hard to express
+//! in Rust, so we instead expose an unsafe *internal* interface with
+//! `&'static` slices, and wrap in the simpler `OwningIovec`.
+
+use std::mem::MaybeUninit;
+use std::num::NonZeroUsize;
+use std::ptr::NonNull;
+use std::sync::atomic::AtomicUsize;
+use std::sync::Arc;
+
+pub static NUM_LIVE_CHUNKS: AtomicUsize = AtomicUsize::new(0);
+pub static NUM_LIVE_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+/// Conceptually, [`Chunk`] is a `Box<[u8]>`, but we convert to/from
+/// [`NonNull`] at construction and destruction in order to avoid
+/// aliasing footguns.
+#[derive(Debug)]
+pub struct Chunk {
+    storage: NonNull<[MaybeUninit<u8>]>,
+}
+
+impl Chunk {
+    #[must_use]
+    pub fn new(storage: Box<[MaybeUninit<u8>]>) -> Chunk {
+        use std::sync::atomic::Ordering;
+        NUM_LIVE_CHUNKS.fetch_add(1, Ordering::Relaxed);
+        NUM_LIVE_BYTES.fetch_add(storage.len(), Ordering::Relaxed);
+
+        Chunk {
+            storage: NonNull::from(Box::leak(storage)),
+        }
+    }
+
+    #[must_use]
+    #[inline(always)]
+    pub fn as_mut_ptr_range(&mut self) -> std::ops::Range<*mut MaybeUninit<u8>> {
+        unsafe { self.storage.as_mut() }.as_mut_ptr_range()
+    }
+}
+
+// We don't use the raw pointer until it's time to `Drop`.
+unsafe impl Send for Chunk {}
+unsafe impl Sync for Chunk {}
+
+impl Drop for Chunk {
+    fn drop(&mut self) {
+        use std::sync::atomic::Ordering;
+
+        let storage = unsafe { Box::from_raw(self.storage.as_mut()) };
+        let capacity = storage.len();
+        std::mem::drop(storage);
+
+        NUM_LIVE_CHUNKS.fetch_sub(1, Ordering::Relaxed);
+        NUM_LIVE_BYTES.fetch_sub(capacity, Ordering::Relaxed);
+    }
+}
+
+/// Each [`Anchor`] keeps a chunk of backing memory alive on behalf of a
+/// number of allocations.
+#[derive(Clone, Debug, Default)]
+pub struct Anchor {
+    count: usize,              // Number of slices that are backed by this [`Anchor`]
+    chunk: Option<Arc<Chunk>>, // Sticky once populated
+}
+
+impl Anchor {
+    /// Constructs a fresh anchor with a strictly positive use count.  The
+    /// positive `count` isn't a requirement, and the value *will* hit zero
+    /// during normal operations, but it's usually a programming mistake to
+    /// initialise an [`Anchor`] with a zero (ref) count.
+    #[must_use]
+    #[inline(always)]
+    fn new(count: NonZeroUsize, chunk: Arc<Chunk>) -> Self {
+        Anchor {
+            count: count.into(),
+            chunk: Some(chunk),
+        }
+    }
+
+    /// Constructs a fresh anchor with no backing chunk.
+    ///
+    /// An anchor may start out with no backing chunk when it's used to
+    /// represent the ownership of borrowed slices.  It's safe to attach a
+    /// chunk to an `Anchor` after the fact: in the worst case, this only
+    /// extends the chunk's lifetime.  That's why it's also safe to increment
+    /// `count` when a borrowed slice is attached to an [`Anchor`].
+    #[must_use]
+    #[inline(always)]
+    pub fn new_with_count(count: NonZeroUsize) -> Self {
+        Anchor {
+            count: count.into(),
+            chunk: None,
+        }
+    }
+
+    /// Returns the number of slices backed by this `Anchor`.
+    #[must_use]
+    #[inline(always)]
+    pub fn count(&self) -> usize {
+        self.count
+    }
+
+    /// Increments the number of slices backed by this `Anchor`.
+    #[inline(always)]
+    pub fn increment_count(&mut self) {
+        self.count += 1
+    }
+
+    /// Decrements the internal (reference) count by up to `decrement`:
+    /// the `count` value stops at 0.
+    ///
+    /// Returns the extra value in `decrement` that could not be
+    /// subtracted from `count`.
+    #[inline(always)]
+    pub fn decrement_count(&mut self, decrement: usize) -> usize {
+        let can_take = self.count.min(decrement);
+        self.count -= can_take;
+        decrement - can_take
+    }
+
+    /// Determins whether this [`Anchor`] holds on to the same
+    /// [`Chunk`] as `chunk`.
+    #[must_use]
+    #[inline(always)]
+    fn is_same_chunk(&self, chunk: &Arc<Chunk>) -> bool {
+        match self.chunk.as_ref() {
+            Some(this) => Arc::ptr_eq(this, chunk),
+            None => false,
+        }
+    }
+
+    /// Increments `count` in `anchor` if it's populated and matches `chunk`.
+    ///
+    /// Returns a fresh anchor otherwise.
+    #[must_use]
+    pub fn merge_ref_or_create(anchor: Option<&mut Self>, chunk: &Arc<Chunk>) -> Option<Self> {
+        let success = match anchor {
+            Some(anchor) if anchor.is_same_chunk(chunk) => {
+                anchor.count += 1;
+                true
+            }
+            _ => false,
+        };
+
+        if success {
+            None
+        } else {
+            Some(Anchor::new(NonZeroUsize::new(1).unwrap(), chunk.clone()))
+        }
+    }
+}

--- a/owning_iovec/src/byte_arena/mod.rs
+++ b/owning_iovec/src/byte_arena/mod.rs
@@ -1,0 +1,621 @@
+//! A `byte_arena` is an arena for [`[u8]`] slices.  It is very
+//! closely inspired by rustc's `DroplessArena`, except that multiple
+//! arenas can share the share underlying backing store (but
+//! allocation caches are private).
+//!
+//! It is only meant for internal use, and lies by returning `'static`
+//! lifetime values. The only user, `OwningIovec`, guarantees that the
+//! returned allocations don't outlive the arena's backing store.
+#![deny(unsafe_op_in_unsafe_fn)]
+mod alloc_cache;
+mod anchor;
+
+use std::io::IoSlice;
+use std::io::Read;
+use std::num::NonZeroUsize;
+use std::sync::atomic::Ordering;
+
+use super::ioslice;
+use alloc_cache::AllocCache;
+pub use anchor::Anchor;
+
+/// A [`ByteArena`] manages allocation caches (bump pointer regions).
+///
+/// While a default-constructed [`ByteArena`] is valid (and does not
+/// allocate anything ahead of time), they're usually obtained through
+/// [`super::ConsumingIovec::take_arena`].
+#[derive(Debug, Default)]
+pub struct ByteArena {
+    cache: Option<AllocCache>,
+}
+
+/// An [`AnchoredSlice`] is a slice of `[u8`] backed by an internal
+/// refcounted allocation.
+///
+/// It's usually obtained by calling [`ByteArena::read_n`], but the
+/// default value is a valid empty slice.
+#[derive(Clone, Debug)]
+pub struct AnchoredSlice {
+    slice: IoSlice<'static>, // actually lives as long as `anchor`.
+    anchor: Anchor,
+}
+
+impl Default for AnchoredSlice {
+    #[inline(always)]
+    fn default() -> Self {
+        const EMPTY: [u8; 0] = [];
+
+        Self {
+            slice: ioslice::make_ioslice(EMPTY.as_ptr() as *mut _, 0),
+            anchor: Default::default(),
+        }
+    }
+}
+
+impl Clone for ByteArena {
+    #[inline(always)]
+    fn clone(&self) -> ByteArena {
+        // Can't clone the `AllocCache`.
+        Default::default()
+    }
+}
+
+/// We try to allocate chunks from this geometrically growing size sequence..
+const BUMP_REGION_SIZE_SEQUENCE: [usize; 9] = [
+    1 << 12,
+    1 << 13,
+    1 << 14,
+    1 << 15,
+    1 << 16,
+    1 << 17,
+    1 << 18,
+    1 << 19,
+    1 << 20,
+];
+
+/// We round to 4KB
+const BUMP_REGION_SIZE_FACTOR: usize = 4096;
+
+// Whenever we allocate from a [`ByteArena`], the allocation is associated
+// with an `Anchor`.  Each anchor has a sticky optional reference to the
+// backing chunk; when all anchors (and the allocation cache) are dropped,
+// the backing memory automatically released.  The [`std::sync::Arc`] in
+// `Anchor` is heavy-weight, so each may stand for multiple allocations.
+//
+// The relationship between `Anchor`s and [`ByteArena`] allocations isn't
+// easy to express in the Rust typesystem, so we instead expose an unsafe
+// interface; this type is only expected to be used via [`crate::OwningIovec`].
+
+impl ByteArena {
+    /// Creates a fresh arena, with a fresh backing store.
+    #[must_use]
+    #[inline(always)]
+    pub fn new() -> ByteArena {
+        Default::default()
+    }
+
+    /// Returns the current number of live (allocated, not yet freed)
+    /// backing arena chunks for all [`ByteArena`] in the process.
+    #[must_use]
+    pub fn num_live_chunks() -> usize {
+        anchor::NUM_LIVE_CHUNKS.load(Ordering::Relaxed)
+    }
+
+    /// Returns the total size in bytes of live (allocated, not yet freed)
+    /// backing arena chunks for all [`ByteArena`] in the process.
+    #[must_use]
+    pub fn num_live_bytes() -> usize {
+        anchor::NUM_LIVE_BYTES.load(Ordering::Relaxed)
+    }
+
+    /// Flushes the arena's internal allocation cache.
+    #[inline(never)] // The destructor can turn into a lot of code.
+    pub fn flush_cache(&mut self) {
+        self.cache = None;
+    }
+
+    /// Returns the number of bytes left in the current allocation cache.
+    #[must_use]
+    #[inline(always)]
+    pub fn remaining(&self) -> usize {
+        match &self.cache {
+            Some(cache) => cache.remaining(),
+            None => 0,
+        }
+    }
+
+    /// Determines whether `slice` was the last slice allocated by the
+    /// [`ByteArena`]'s current allocation cache.
+    #[must_use]
+    #[inline(always)]
+    pub fn is_last(&self, slice: IoSlice<'_>) -> bool {
+        match &self.cache {
+            Some(cache) => {
+                unsafe { self.contains(slice) }.is_some()
+                    & (slice.as_ptr_range().end as usize == cache.next_alloc_address())
+            }
+            None => false,
+        }
+    }
+
+    /// Ensure the current allocation cache has room for at least `len` bytes.
+    #[inline(always)]
+    pub fn ensure_capacity(&mut self, len: usize) {
+        self.ensure_capacity_internal(len);
+    }
+
+    #[inline(never)]
+    fn ensure_capacity_internal(&mut self, len: usize) -> &mut AllocCache {
+        let (ok, initial_size) = match self.cache.as_mut() {
+            Some(cache) => {
+                let initial_size = cache.initial_size();
+                (cache.remaining() >= len, initial_size)
+            }
+            None => (false, 0),
+        };
+
+        if ok {
+            // We just checked that the cache is non-empty and has enough room.
+            self.cache.as_mut().unwrap()
+        } else {
+            // Drop the old one before allocating a new cache.
+            self.cache = None;
+
+            // Find the "ideal" size if we have to allocate fresh.
+            let hint = Self::find_hint_size(len, initial_size);
+            let cache = AllocCache::new(len, hint);
+            assert!(cache.remaining() >= len);
+            self.cache.insert(cache)
+        }
+    }
+
+    /// Find the "ideal" chunk size if we have to allocate a fresh chunk.
+    fn find_hint_size(len: usize, prev_capacity: usize) -> usize {
+        let max_size_sequence = *BUMP_REGION_SIZE_SEQUENCE.last().unwrap();
+
+        if len >= max_size_sequence {
+            // We're asking a large capacity, just round that up to a multiple of BUMP_REGION_SIZE_FACTOR
+            let hint = len
+                .div_ceil(BUMP_REGION_SIZE_FACTOR)
+                .saturating_mul(BUMP_REGION_SIZE_FACTOR);
+            assert!(hint >= len);
+            return hint;
+        }
+
+        if prev_capacity >= max_size_sequence {
+            // We're already at the max size, stay there.
+            assert!(len < max_size_sequence);
+
+            let hint = max_size_sequence;
+            assert!(hint >= len);
+            return hint;
+        }
+
+        // len < max_size_sequence, initial_size < max_size_sequence
+        let wanted = prev_capacity.saturating_add(1).max(len);
+        assert!(wanted <= max_size_sequence);
+
+        // Default to `max_size_sequence`
+        let mut hint = max_size_sequence;
+        // But try to find the first element in the size sequence that's at least equal to `wanted`.
+        for size in BUMP_REGION_SIZE_SEQUENCE {
+            if size >= wanted {
+                hint = size;
+                break;
+            }
+        }
+
+        assert!(hint >= len);
+        // We must grow if we get here.
+        assert!(hint > prev_capacity);
+
+        hint
+    }
+
+    /// Checks whether `slice` definitely comes from this [`ByteArena`]'s backing storage.
+    ///
+    /// If so, returns a static lifetime slice.
+    ///
+    /// # Safety
+    ///
+    /// The return value's lifetime is a lie.  This method should only be used in
+    /// `try_join`.
+    #[must_use]
+    #[inline(always)]
+    unsafe fn contains(&self, slice: IoSlice<'_>) -> Option<IoSlice<'static>> {
+        let range = &self.cache.as_ref()?.range();
+        let (iov_base, iov_len) = ioslice::ioslice_components(slice);
+        let base = iov_base as usize;
+        let end = base + iov_len;
+
+        if (range.start <= base) & (end <= range.end) {
+            Some(ioslice::make_ioslice(iov_base, iov_len))
+        } else {
+            None
+        }
+    }
+
+    /// Checks whether `left` and `right` are adjacent subslices that
+    /// definitely come from the same underlying allocation.
+    ///
+    /// If so, returns a static lifetime slice for their concatenation.
+    ///
+    /// # Safety
+    ///
+    /// The return value must not outlast the slices' anchor(s).  The
+    /// static lifetime is a lie.
+    #[must_use]
+    #[inline(always)]
+    pub(crate) unsafe fn try_join(
+        &self,
+        left: IoSlice<'_>,
+        right: IoSlice<'_>,
+    ) -> Option<IoSlice<'static>> {
+        if let (Some(left), Some(right)) = unsafe { (self.contains(left), self.contains(right)) } {
+            let left = ioslice::ioslice_components(left);
+            let right = ioslice::ioslice_components(right);
+            if (left.0 as usize + left.1) == (right.0 as usize) {
+                return Some(ioslice::make_ioslice(left.0, left.1 + right.1));
+            }
+        }
+
+        None
+    }
+
+    /// Internal slow path for `alloc`: we make sure there's capacity for `len`
+    /// bytes and ask for that many.
+    #[inline(never)]
+    fn grow_and_alloc(
+        &mut self,
+        len: usize,
+        old_anchor: Option<&mut Anchor>,
+    ) -> (IoSlice<'static>, Option<Anchor>) {
+        let cache = self.ensure_capacity_internal(len);
+        // we just ensured capacity
+        unsafe { cache.alloc_or_die(len, old_anchor) }
+    }
+
+    /// Allocates a slice of `len` bytes from this [`ByteArena`].
+    ///
+    /// When `old_anchor` is provided and matches the current backing
+    /// chunk, increments its internal allocation count.  Otherwise,
+    /// returns a fresh anchor.
+    ///
+    /// # Safety
+    ///
+    /// The return value must not outlast the `old_anchor` or the new
+    /// anchor.  We lie with `'static` because `OwningIovec` just has
+    /// to get it right.
+    #[must_use]
+    #[inline(always)]
+    pub(crate) unsafe fn alloc(
+        &mut self,
+        len: NonZeroUsize,
+        old_anchor: Option<&mut Anchor>,
+    ) -> (IoSlice<'static>, Option<Anchor>) {
+        // The cache grabs bytes from a slice that belongs to
+        // `self.backing`, so the storage lives at least as long as
+        // the anchor.
+        let len: usize = len.into();
+        if self.remaining() >= len {
+            let cache = self.cache.as_mut().expect("capacity > 0");
+            // we already checked for capacity
+            unsafe { cache.alloc_or_die(len, old_anchor) }
+        } else {
+            self.grow_and_alloc(len, old_anchor)
+        }
+    }
+
+    /// Allocates a copy of `src` from this `ByteArena`.  Panics if
+    /// `src` is empty.
+    ///
+    /// When `old_anchor` is provided and matches the current backing
+    /// chunk, increments its internal allocation count.  Otherwise,
+    /// returns a fresh anchor.
+    ///
+    /// # Safety
+    ///
+    /// The return value must not outlast the `old_anchor` or the new
+    /// anchor.  We lie with `'static` because `OwningIovec` just has
+    /// to get it right.
+    #[must_use]
+    #[inline(always)]
+    pub(crate) unsafe fn copy(
+        &mut self,
+        src: &[u8],
+        old_anchor: Option<&mut Anchor>,
+    ) -> (IoSlice<'static>, Option<Anchor>) {
+        // zero-sized allocation and memcpy have surprising aliasing consequences.
+        assert!(!src.is_empty());
+
+        let (dst, anchor) =
+            unsafe { self.alloc(NonZeroUsize::new(src.len()).unwrap(), old_anchor) };
+
+        let (dst_ptr, len) = ioslice::ioslice_components(dst);
+
+        assert_eq!(len, src.len());
+        unsafe { dst_ptr.copy_from_nonoverlapping(src.as_ptr(), len) };
+
+        (ioslice::make_ioslice(dst_ptr, len), anchor)
+    }
+}
+
+impl AnchoredSlice {
+    /// Returns the anchored data.
+    #[must_use]
+    #[inline(always)]
+    pub fn slice(&self) -> &[u8] {
+        &self.slice
+    }
+
+    /// Swaps `self` with an empty [`AnchoredSlice`] and returns
+    /// the initial `self` slice.
+    #[must_use]
+    #[inline(always)]
+    pub fn take(&mut self) -> AnchoredSlice {
+        let mut ret: AnchoredSlice = Default::default();
+        std::mem::swap(self, &mut ret);
+        ret
+    }
+
+    /// Skips up to the first `count` bytes in the anchored data,
+    /// less if `count` is greater than the data's size.
+    ///
+    /// Returns the number of bytes actually skipped.
+    #[inline(always)]
+    pub fn skip_prefix(&mut self, count: usize) -> usize {
+        let (mut base, mut len) = ioslice::ioslice_components(self.slice);
+
+        let count = count.min(len);
+        base = unsafe { base.add(count) };
+        len -= count;
+        self.slice = ioslice::make_ioslice(base, len);
+        count
+    }
+
+    /// Drops up to the last `count` bytes in the anchored data,
+    /// less if `count` is greater than the data's size.
+    ///
+    /// Returns the number of bytes actually skipped.
+    #[inline(always)]
+    pub fn drop_suffix(&mut self, count: usize) -> usize {
+        let (base, mut len) = ioslice::ioslice_components(self.slice);
+        let count = count.min(len);
+        len -= count;
+        self.slice = ioslice::make_ioslice(base, len);
+        count
+    }
+
+    /// Splits this `AnchoredSlice` in two parts: the first one has the
+    /// first `mid` bytes (or the whole slice), and the second has any
+    /// remaining data.
+    #[must_use]
+    pub fn split_at(self, mid: usize) -> (AnchoredSlice, AnchoredSlice) {
+        let (base, len) = ioslice::ioslice_components(self.slice);
+        if mid >= len {
+            (self, Default::default())
+        } else {
+            let left_slice = ioslice::make_ioslice(base, mid);
+            let right_slice = ioslice::make_ioslice(unsafe { base.add(mid) }, len - mid);
+
+            let left = AnchoredSlice {
+                slice: left_slice,
+                anchor: self.anchor.clone(),
+            };
+            let right = AnchoredSlice {
+                slice: right_slice,
+                anchor: self.anchor,
+            };
+
+            (left, right)
+        }
+    }
+
+    /// Explodes the `AnchoredSlice` in a slice and an anchor.  The slice's
+    /// `static` lifetime is a lie: it really only lives as long as `Anchor`.
+    ///
+    /// # Safety
+    ///
+    /// Calling `AnchoredSlice::components` is safe in itself, but the
+    /// returned slice's lifetime is a lie.  It must never actually
+    /// outlive its `Anchor`.
+    #[must_use]
+    #[inline(always)]
+    pub unsafe fn components(self) -> (IoSlice<'static>, &'static [u8], Anchor) {
+        let (base, len) = ioslice::ioslice_components(self.slice);
+        let slice = unsafe { std::slice::from_raw_parts(base as *const u8, len) };
+        (self.slice, slice, self.anchor)
+    }
+}
+
+impl ByteArena {
+    /// Reads up to `count` bytes from `src`, by making up to `max_attempts` calls
+    /// to `Read::read`.
+    ///
+    /// Returns the resulting slice on success.
+    ///
+    /// This method retries on [`std::io::ErrorKind::Interrupted`] and
+    /// short reads.  It stops at the first error or zero-sized read
+    /// (EOF).  Calls to this method always succeed when at least 1
+    /// byte was read; otherwise, the method returns the last error
+    /// encountered (the first non-`EINTR`, unless it's all `EINTR`).
+    ///
+    /// This method returns `Ok(0)` iff `src.read()` does as well, i.e.,
+    /// on EOF.  A string of `max_attempts` [`std::io::ErrorKind::Interrupted`]
+    /// instead results in returning that as an error.
+    pub fn read_n(
+        &mut self,
+        src: impl Read,
+        count: usize,
+        max_attempts: NonZeroUsize,
+    ) -> std::io::Result<AnchoredSlice> {
+        if count == 0 {
+            return Ok(Default::default());
+        }
+
+        let (raw_slice, anchor) = unsafe { self.alloc(NonZeroUsize::new(count).unwrap(), None) };
+        let (base, len) = ioslice::ioslice_components(raw_slice);
+        assert_eq!(len, count);
+        let slice: &'static mut [u8] = unsafe { std::slice::from_raw_parts_mut(base, count) };
+
+        match self.read_n_impl(src, slice, max_attempts) {
+            Ok(got) => {
+                assert!(got <= count);
+                let got_slice = ioslice::make_ioslice(base, got);
+                let remainder = ioslice::make_ioslice(unsafe { base.add(got) }, count - got);
+                self.cache.as_mut().unwrap().release_or_die(remainder);
+
+                Ok(AnchoredSlice {
+                    slice: got_slice,
+                    anchor: anchor.unwrap_or_default(),
+                })
+            }
+            Err(e) => {
+                // We just got an allocation, the cache isn't empty.
+                self.cache.as_mut().unwrap().release_or_die(raw_slice);
+                Err(e)
+            }
+        }
+    }
+
+    fn read_n_impl(
+        &mut self,
+        mut src: impl Read,
+        slice: &'static mut [u8],
+        max_attempts: NonZeroUsize,
+    ) -> std::io::Result<usize> {
+        slice.fill(0); // XXX: unfortunately...
+        let mut got = 0usize;
+        let mut err: Option<std::io::Error> = None;
+
+        for _ in 0..max_attempts.get() {
+            let ret = src.read(&mut slice[got..]);
+
+            match ret {
+                Ok(count) => {
+                    got += count;
+                    if count == 0 {
+                        // EOF: bail out with Ok(len).
+                        err = None;
+                        break;
+                    }
+                }
+                Err(e) => {
+                    let kind = e.kind();
+                    err.replace(e);
+                    if kind != std::io::ErrorKind::Interrupted {
+                        // Stop at the first real error.
+                        break;
+                    }
+                }
+            }
+
+            if got == slice.len() {
+                break;
+            }
+        }
+
+        match (got, err) {
+            (0, Some(e)) => Err(e),
+            _ => Ok(got),
+        }
+    }
+}
+
+// This is mostly an internal class.  It's really tested through its
+// main user, `owning_iovec`.
+
+// Check that we correctly round up to at least the allocation size,
+// and don't consider the previous capacity when doing so.
+#[test]
+fn test_size_sequence_large_miri() {
+    // Huge allocation -> just round up.
+    assert_eq!(ByteArena::find_hint_size(2_000_000, 4096), 2002944);
+    assert_eq!(2002944, 489 * 4096);
+
+    // Same, regardless of the previous size
+    assert_eq!(
+        ByteArena::find_hint_size(2 * 1024 * 1024, 4_000_000),
+        2 * 1024 * 1024
+    );
+}
+
+// Check that we don't try to grow past the maximum region size when
+// the mandatory size is small.
+#[test]
+fn test_size_sequence_grow_capped_miri() {
+    // Small allocation, but large initial size.  Stay at the max value.
+    let max = *BUMP_REGION_SIZE_SEQUENCE.last().unwrap();
+    assert_eq!(ByteArena::find_hint_size(1, max - 1), max);
+    assert_eq!(ByteArena::find_hint_size(1, max), max);
+    assert_eq!(ByteArena::find_hint_size(4096, 2_000_000), max);
+}
+
+// Check that we grow geometrically.
+#[test]
+fn test_size_sequence_grow_miri() {
+    assert_eq!(
+        ByteArena::find_hint_size(1, 0),
+        *BUMP_REGION_SIZE_SEQUENCE.first().unwrap()
+    );
+
+    let max = *BUMP_REGION_SIZE_SEQUENCE.last().unwrap();
+    for value in BUMP_REGION_SIZE_SEQUENCE.iter().copied() {
+        let hint = ByteArena::find_hint_size(1, value);
+        if value == max {
+            assert_eq!(hint, max);
+        } else {
+            assert!(hint > value);
+            // Growth must be geometric.
+            assert_eq!(hint, 2 * value);
+            assert!(hint <= max);
+        }
+    }
+}
+
+#[test]
+fn test_anchored_slice_miri() {
+    let mut arena = ByteArena::new();
+    let (data, anchor) = unsafe { arena.copy(b"0123456789", None) };
+
+    let mut slice = AnchoredSlice {
+        slice: data,
+        anchor: anchor.unwrap(),
+    };
+
+    assert_eq!(slice.slice(), b"0123456789");
+
+    assert_eq!(slice.skip_prefix(1), 1);
+    assert_eq!(slice.slice(), b"123456789");
+
+    assert_eq!(slice.drop_suffix(1), 1);
+    assert_eq!(slice.slice(), b"12345678");
+
+    let (mut left, right) = slice.split_at(5);
+    assert_eq!(left.slice(), b"12345");
+    assert_eq!(right.slice(), b"678");
+
+    let mut other_left = left.clone();
+
+    // Check that skipping more than the size drops everything.
+    assert_eq!(left.skip_prefix(100), 5);
+    assert_eq!(left.slice(), b"");
+    std::mem::drop(left);
+
+    // Check that dropping more than the size drops everything.
+    assert_eq!(other_left.slice(), b"12345");
+    assert_eq!(other_left.drop_suffix(10), 5);
+    assert_eq!(other_left.slice(), b"");
+    std::mem::drop(other_left);
+
+    // Check that splitting at 0 is a no-op;
+    let (left, right) = right.split_at(0);
+    assert_eq!(left.slice(), b"");
+    std::mem::drop(left);
+    assert_eq!(right.slice(), b"678");
+
+    // Check that splitting past the end is a near no-op.
+    let (right, empty) = right.split_at(1000);
+    assert_eq!(right.slice(), b"678");
+    assert_eq!(empty.slice(), b"");
+}

--- a/owning_iovec/src/global_deque.rs
+++ b/owning_iovec/src/global_deque.rs
@@ -1,0 +1,277 @@
+use std::collections::VecDeque;
+use std::io::IoSlice;
+use std::num::NonZeroUsize;
+
+use sliding_deque::SlidingVec;
+
+use super::byte_arena::Anchor;
+
+/// The `GlobalDeque` is a `SlidingDeque` of `IoSlice` that tracks the
+/// current logical (monotonically increasing) position and size, and
+/// maps between that and the physical locations, taking into account
+/// the `IoSlice`s and bytes consumed.
+///
+/// Each slice is also backed by one [`Anchor`] in `anchors`.  Slices
+/// (and anchors) may be appended to the end of the [`GlobalDeque`],
+/// merged at the end, or consumed from the front.  The caller ([`OwningIovec`])
+/// is responsible for capping consumption if it holds backreferences
+/// into `slices`.
+///
+/// The usage of the `this` lifetime can be unsound; we rely on constraints
+/// on the surrounding [`OwningIovec`] to avoid dangling slices.
+#[derive(Debug, Default, Clone)]
+pub struct GlobalDeque<'this> {
+    slices: SlidingVec<IoSlice<'this>>,
+    anchors: VecDeque<Anchor>, // Each anchor is responsible for a contiguous number (> 0) of slices.
+    logical_size: u64,
+    consumed_size: u64,
+    consumed_slices: u64,
+}
+
+impl<'this> GlobalDeque<'this> {
+    #[must_use]
+    pub fn new(slices: Vec<IoSlice<'this>>) -> Self {
+        let logical_size = slices.iter().map(|slice| slice.len() as u64).sum();
+        let mut anchors = VecDeque::new();
+
+        if !slices.is_empty() {
+            let count = NonZeroUsize::new(slices.len()).expect("slices isn't empty");
+            anchors.push_back(Anchor::new_with_count(count));
+        }
+
+        GlobalDeque {
+            slices: slices.into(),
+            anchors,
+            logical_size,
+            consumed_size: 0,
+            consumed_slices: 0,
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.slices.clear();
+        self.anchors.clear();
+        self.logical_size = 0;
+        self.consumed_size = 0;
+        self.consumed_slices = 0;
+    }
+
+    /// Pushes a new slice at the end of the deque.  If we have an anchor
+    /// it's pushed to the back of the anchor deque; otherwise, we assume
+    /// the current last anchor has been mutated in place to take the
+    /// new slice into account.
+    pub fn push(&mut self, entry: (IoSlice<'this>, Option<Anchor>)) {
+        let (slice, anchor) = entry;
+
+        // This shouldn't happen, but it doesn't hurt to be defensive:
+        // consumers want to assume there are no empty slices.
+        #[cfg(not(test))]
+        if slice.is_empty() {
+            return;
+        }
+
+        assert!(!slice.is_empty());
+
+        self.logical_size += slice.len() as u64;
+        self.slices.push_back(slice);
+        if let Some(anchor) = anchor {
+            self.anchors.push_back(anchor);
+        } else {
+            assert!(!self.anchors.is_empty());
+        }
+    }
+
+    /// Pushes a borrowed slice (guaranteed to outlive the `GlobalDeque`)
+    /// at the end of the deque.
+    pub fn push_borrowed(&mut self, slice: IoSlice<'this>) {
+        #[cfg(not(test))]
+        if slice.is_empty() {
+            return;
+        }
+
+        assert!(!slice.is_empty());
+
+        self.logical_size += slice.len() as u64;
+        self.slices.push_back(slice);
+
+        if self.anchors.is_empty() {
+            self.anchors.push_back(Default::default());
+        }
+
+        self.anchors.back_mut().unwrap().increment_count();
+    }
+
+    #[inline(always)]
+    pub fn push_anchor(&mut self, mut anchor: Anchor) {
+        anchor.decrement_count(anchor.count());
+        self.anchors.push_back(anchor);
+    }
+
+    #[must_use]
+    #[inline(always)]
+    pub fn last_anchor(&mut self) -> Option<&mut Anchor> {
+        self.anchors.back_mut()
+    }
+
+    #[must_use]
+    #[inline(always)]
+    pub fn last_slice(&self) -> Option<IoSlice<'this>> {
+        self.slices.last().copied()
+    }
+
+    #[must_use]
+    #[inline(always)]
+    pub fn logical_size(&self) -> u64 {
+        self.logical_size
+    }
+
+    #[must_use]
+    #[inline(always)]
+    pub fn last_logical_slice_index(&self) -> u64 {
+        self.consumed_slices + (self.slices.len() as u64) - 1
+    }
+
+    #[must_use]
+    #[inline(always)]
+    pub fn get_logical_slice(&self, index: u64) -> Option<IoSlice<'this>> {
+        let index = index
+            .wrapping_sub(self.consumed_slices)
+            .min(usize::MAX as u64) as usize;
+
+        self.slices.get(index).copied()
+    }
+
+    /// Gets the prefix of slices we can look at *before* the logical slice index
+    /// `end_logical_slice`.
+    #[inline(always)]
+    pub fn get_logical_prefix(&self, end_logical_slice: Option<u64>) -> &[IoSlice<'this>] {
+        let end_logical_slice = end_logical_slice.unwrap_or(u64::MAX);
+        let remainder = end_logical_slice - self.consumed_slices;
+        let take = remainder.min(self.slices.len() as u64) as usize;
+
+        &self.slices[..take]
+    }
+
+    /// Drops the first `count` slices in the deque.
+    #[inline(never)]
+    pub fn consume(&mut self, count: usize) -> usize {
+        let count = count.min(self.slices.len());
+
+        let consumed_size: u64 = self.slices[..count]
+            .iter()
+            .map(|slice| slice.len() as u64)
+            .sum();
+        self.consumed_size += consumed_size;
+        self.consumed_slices += count as u64;
+
+        let consumed = self.slices.advance(count);
+        assert_eq!(consumed, count);
+
+        let mut num_to_drain = consumed;
+        while num_to_drain > 0 {
+            let front = self
+                .anchors
+                .front_mut()
+                .expect("must have front if we consumed some slices");
+            num_to_drain = front.decrement_count(num_to_drain);
+            if front.count() == 0 {
+                // We made progress!
+                self.anchors.pop_front();
+            } else {
+                // Or we're done.
+                assert_eq!(num_to_drain, 0);
+            }
+        }
+
+        // Drop any zero-count anchor at the front.
+        while let Some(anchor) = self.anchors.front() {
+            if anchor.count() > 0 {
+                break;
+            }
+
+            self.anchors.pop_front();
+        }
+
+        // slices js empty iff anchors are as well.
+        assert!(self.slices.is_empty() == self.anchors.is_empty());
+
+        count
+    }
+
+    /// Drops the first `count` bytes in the deque.  Any partially consumed
+    /// final slice is advanced in place.
+    #[inline(never)]
+    pub fn consume_by_bytes(&mut self, count: usize) -> usize {
+        let mut consumed = 0;
+
+        while consumed < count {
+            let slice = self
+                .slices
+                .front_mut()
+                .expect("OwningIovec bound-checks upstream");
+
+            let len = slice.len();
+            let num_to_consume = (count - consumed).min(slice.len());
+            let ptr = slice.as_ptr();
+
+            let new_slice = unsafe {
+                std::slice::from_raw_parts(ptr.add(num_to_consume), len - num_to_consume)
+            };
+            if new_slice.is_empty() {
+                // XXX: should we consume the full sized slices in bulk?
+                self.consume(1);
+            } else {
+                *slice = IoSlice::new(new_slice);
+                self.consumed_size += num_to_consume as u64;
+                assert_eq!(num_to_consume, count - consumed);
+            }
+
+            consumed += num_to_consume;
+        }
+
+        consumed
+    }
+
+    /// Returns the total number of slices.
+    #[must_use]
+    #[inline(always)]
+    pub fn num_slices(&self) -> usize {
+        self.slices.len()
+    }
+
+    /// Returns the total number of bytes in the slices.
+    #[must_use]
+    #[inline(always)]
+    pub fn total_size(&self) -> usize {
+        (self.logical_size - self.consumed_size) as usize
+    }
+
+    /// Attempts to collapse the last two slices in the deque into a
+    /// single slice, if it's safe to do so.
+    pub fn maybe_collapse_last_pair(
+        &mut self,
+        collapse: impl FnOnce(IoSlice<'this>, IoSlice<'this>) -> Option<IoSlice<'this>>,
+    ) {
+        let len = self.slices.len();
+        if len < 2 {
+            return;
+        }
+
+        let anchor = self
+            .anchors
+            .back_mut()
+            .expect("must have anchor for slices");
+        assert!(anchor.count() > 0);
+        if anchor.count() < 2 {
+            return;
+        }
+
+        if let Some(merger) = collapse(self.slices[len - 2], self.slices[len - 1]) {
+            self.slices.pop_back();
+            *self.slices.back_mut().unwrap() = merger;
+            // We can only collapse when the two slices are from the same
+            // chunk, so we only had one for both anchor.
+            anchor.decrement_count(1);
+        }
+    }
+}

--- a/owning_iovec/src/implementation.rs
+++ b/owning_iovec/src/implementation.rs
@@ -1,0 +1,992 @@
+use std::io::IoSlice;
+use std::num::NonZeroUsize;
+
+use sliding_deque::SortedDeque;
+use smallvec::SmallVec;
+
+use super::byte_arena::Anchor;
+use super::byte_arena::ByteArena;
+use super::global_deque::GlobalDeque;
+use super::ioslice;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct BackrefInfo {
+    slice_index: u64,  // Global iov index
+    begin: usize,      // Range in the target iov
+    len: NonZeroUsize, // Size of the range
+}
+
+/// Each [`Backref`] represents a capability to
+/// backfill some bytes owned by an [`OwningIovec`].
+///
+/// They are returned by [`OwningIovec::register_patch`], and
+/// backfilled by [`OwningIovec::backfill_or_panic`].  Backreference
+/// are not clonable, so cloning an `OwningIovec` that has in-flight
+/// backreferences isn't super useful.
+///
+/// A default-constructed [`Backref`] represents a 0-sized
+/// backpatch.
+#[derive(Debug, Default)]
+#[repr(transparent)]
+#[must_use]
+pub struct Backref(Option<(u64, BackrefInfo)>);
+
+impl Backref {
+    /// Returns the number of bytes in the backref
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.0.map(|(_, info)| info.len.into()).unwrap_or(0)
+    }
+
+    /// Determines whether the backref spans 0 bytes.  In practice,
+    /// we don't expect to generate empty backreferences.
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+type ErasableBackrefInfo = (u64, Option<BackrefInfo>);
+
+/// An [`OwningIovec`] is a [`Vec<IoSlice<>>`] that may optionally own
+/// some of it slices' pointees.  Some of the owned pointees may be
+/// backpatched after the fact, and it's possible to peek at and consume
+/// the first `IoSlice`s that aren't waiting for a backpatch.
+///
+/// Internally, owned slices are allocated from an internal arena
+/// with `Arc` to the backing allocations tracked internally.
+#[derive(Debug, Default, Clone)]
+pub struct OwningIovec<'this> {
+    // The `GlobalDeque` manages the mapping between slices and
+    // Anchors, but is oblivious to backreferences.  Always bound
+    // check *that* before accessing `slices`.
+    //
+    // XXX: we internally guarantee to never push empty slices in
+    // there, and the global deque itself skips empty slices.
+    slices: GlobalDeque<'this>,
+
+    // We allocate from `arena`, but only to stick values in `iovs`,
+    // and this `ByteArena` is static for the lifetime of the
+    // `OwningIovec`.
+    arena: ByteArena,
+
+    // The first value is the key, the logical byte index of the
+    // backreference in the [`GlobalDeque`], and the second value
+    // if the info, if the backref is still in flight (None when
+    // logically deleted).
+    backrefs: SortedDeque<SmallVec<[ErasableBackrefInfo; 4]>>, // Pending backrefs
+}
+
+/// [`ConsumingIovec`] is a mutable reference to an [`OwningIovec`]
+/// that only exposes consuming operations (i.e., can't put slices
+/// in).  It can also be derefed as a const ref to [`OwningIovec`],
+/// for read-only methods.  The 'a lifetime stands for the inner
+/// `OwningIovec`'s lifetime, which must not exceed the slice's.
+///
+/// This dataflow means we only want covariance (like regular references).
+#[derive(Debug)]
+#[repr(transparent)]
+// We do not need a PhantomData<OwningIovec<'a>> because `ConsumingIovec`
+// does not own the `OwningIovec` (and further `OwningIovec` does not
+// look at the 'life-slices' contents when it drops).
+// (https://github.com/rust-lang/rfcs/blob/master/text/0769-sound-generic-drop.md#phantom-data).
+//
+// NonNull is safe because we do want covariance in 'a.
+pub struct ConsumingIovec<'a>(std::ptr::NonNull<OwningIovec<'a>>);
+
+/// A [`StableIovec`] is a [`ConsumingIovec`] constructed from an
+/// [`OwningIovec`] that does not have any backreference in flight.
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct StableIovec<'a>(ConsumingIovec<'a>);
+
+impl<'slices> ConsumingIovec<'slices> {
+    /// ConsumingIovec does not implement Clone, and iovec accepts a
+    /// mutable reference, so this internal pointer must be an
+    /// exclusive reference to the pointee.  It's safe to convert back
+    /// to &mut, because this wrapper acts like &mut &mut.
+    ///
+    /// We know the `OwningIovec` itself is only safe to keep around
+    /// for `'a`.  We also know the slices' lifetime is at least as wide,
+    /// so we force them to `'a` too; there's no lost functionality
+    /// because read-side methods restrict the slices' lifetime to the
+    /// same as the `OwningIovec` (to take into account owned slices).
+    #[must_use]
+    #[inline(always)]
+    fn iovec<'this>(&'this mut self) -> &'this mut OwningIovec<'slices>
+    where
+        'slices: 'this, // slices must outlive this for NonNull, but let's be explicit.
+    {
+        unsafe { self.0.as_mut() }
+    }
+}
+
+impl<'a> std::convert::From<&'a mut OwningIovec<'_>> for ConsumingIovec<'a> {
+    // It's important to constraint the `&mut OwningIovec` with `'a`:
+    // the slices can have an arbitrary wider lifetime than the OwningIovec,
+    // (e.g., `OwningIovec<'static>`).  For reading purposes, it's safe
+    // to narrow the slices' lifetime to the same `'a` as the iovec:
+    // we only borrow/copy slices out of the iovec, and all const methods
+    // force the output slices' lifetime to match the iovec's.
+    #[inline(always)]
+    fn from(iovec: &'a mut OwningIovec<'_>) -> ConsumingIovec<'a> {
+        ConsumingIovec(iovec.into())
+    }
+}
+
+/// A [`ConsumingIovec`] can be converted to a [`StableIovec`] if
+/// there are no backref in flight;  otherwise, the input [`ConsumingIovec`]\
+/// is returned back as the error.
+impl<'a> std::convert::TryFrom<ConsumingIovec<'a>> for StableIovec<'a> {
+    type Error = ConsumingIovec<'a>;
+
+    #[inline(always)]
+    fn try_from(iovec: ConsumingIovec<'a>) -> Result<StableIovec<'a>, ConsumingIovec<'a>> {
+        if iovec.has_pending_backrefs() {
+            Err(iovec)
+        } else {
+            Ok(StableIovec(iovec))
+        }
+    }
+}
+
+// No DerefMut because the whole point of `ConsumingIovec` is to
+// only allow the consuming subset of mutable methods.
+impl<'a> std::ops::Deref for ConsumingIovec<'a> {
+    type Target = OwningIovec<'a>;
+
+    #[inline(always)]
+    fn deref(&self) -> &OwningIovec<'a> {
+        unsafe { self.0.as_ref() }
+    }
+}
+
+impl<'a> std::ops::Deref for StableIovec<'a> {
+    type Target = ConsumingIovec<'a>;
+
+    #[inline(always)]
+    fn deref(&self) -> &ConsumingIovec<'a> {
+        &self.0
+    }
+}
+
+impl<'a> std::ops::DerefMut for StableIovec<'a> {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut ConsumingIovec<'a> {
+        &mut self.0
+    }
+}
+
+/// Always copy when the source is at most this long.
+const SMALL_COPY: usize = 64;
+
+/// Copy when the source is at most this long and we'd extend the last IoSlice.
+const MAX_OPPORTUNISTIC_COPY: usize = 256;
+
+#[must_use]
+#[inline(always)]
+fn ioslice_len(slice: IoSlice<'_>) -> usize {
+    ioslice::ioslice_components(slice).1
+}
+
+impl<'this> OwningIovec<'this> {
+    /// Creates an empty instance that will allocate from its fresh
+    /// private arena.
+    #[must_use]
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Creates an empty instance that will allocate from `arena`
+    #[must_use]
+    pub fn new_from_arena(arena: ByteArena) -> Self {
+        OwningIovec::new_from_slices(Vec::new(), Some(arena))
+    }
+
+    /// Creates a new instance with these initial [`IoSlice`]s
+    /// and the arena, if provided; uses a fresh arena if [`None`].
+    #[must_use]
+    pub fn new_from_slices(mut slices: Vec<IoSlice<'this>>, arena: Option<ByteArena>) -> Self {
+        slices.retain(|slice| slice.len() > 0);
+        OwningIovec {
+            slices: GlobalDeque::new(slices),
+            arena: arena.unwrap_or_default(),
+            ..Default::default()
+        }
+    }
+
+    /// Returns a reference to the underlying arena
+    #[must_use]
+    #[inline(always)]
+    pub fn arena(&mut self) -> &mut ByteArena {
+        &mut self.arena
+    }
+
+    /// Returns a [`ConsumingIovec`] for this [`OwningIovec`].
+    #[must_use]
+    #[inline(always)]
+    pub fn consumer(&mut self) -> ConsumingIovec<'_> {
+        self.into()
+    }
+
+    /// Attempts to return a [`StableIovec`] for this [`OwningIovec`].
+    /// Returns a [`ConsumingIovec`] as the `Err` if this [`OwningIovec`]
+    /// has backreferences in flight.
+    #[inline(always)]
+    pub fn stable_consumer(&mut self) -> Result<StableIovec<'_>, ConsumingIovec<'_>> {
+        self.consumer().try_into()
+    }
+
+    /// Replaces `self` with a default-constructued [`OwningIovec`] and
+    /// returns the initial `self`.
+    #[must_use]
+    pub fn take(&mut self) -> Self {
+        let mut ret = Default::default();
+        std::mem::swap(self, &mut ret);
+        ret
+    }
+
+    /// Clears the internal state (buffered slices and pending backreferences),
+    /// but keeps the backing [`ByteArena`] untouched.
+    pub fn clear(&mut self) {
+        self.slices.clear();
+        self.backrefs.clear();
+    }
+
+    /// Pushes `slice` to the internal vector of [`IoSlice`]s.
+    ///
+    /// Small slices are copied, large ones borrowed, and
+    /// medium-sized one may be copied when it makes sense.
+    ///
+    /// This method takes constant amortised time wrt `slice.len()`.
+    pub fn push(&mut self, slice: &'this [u8]) {
+        let small = slice.len() <= SMALL_COPY;
+        let appendable = (slice.len() <= MAX_OPPORTUNISTIC_COPY)
+            & (self.arena.remaining() >= slice.len())
+            & (self
+                .slices
+                .last_slice()
+                .map(|slice| self.arena.is_last(slice))
+                == Some(true));
+
+        if small | appendable {
+            self.push_copy(slice);
+        } else {
+            self.push_borrowed(slice);
+        }
+    }
+
+    /// Pushes `slice` to the internal vector of [`IoSlice`],
+    /// without copying the contents.
+    ///
+    /// This method takes constant amortised time wrt `slice.len()`.
+    pub fn push_borrowed(&mut self, slice: &'this [u8]) {
+        if slice.is_empty() {
+            return;
+        }
+
+        self.slices.push_borrowed(IoSlice::new(slice));
+        self.optimize();
+    }
+
+    /// Pushes a copy of `src` to the internal vector of [`IoSlice`].
+    ///
+    /// This method takes lines time wrt `slice.len()`.
+    pub fn push_copy(&mut self, src: &[u8]) {
+        if src.is_empty() {
+            return;
+        }
+
+        let last_anchor = self.slices.last_anchor();
+        let (slice, anchor) = unsafe { self.arena.copy(src, last_anchor) };
+        self.slices.push((slice, anchor));
+        self.optimize();
+    }
+
+    /// Extends the internal vector of [`IoSlice`]s with each item in `iovs`.
+    pub fn extend(&mut self, iovs: impl IntoIterator<Item = IoSlice<'this>>) {
+        for iov in iovs {
+            if iov.is_empty() {
+                continue;
+            }
+
+            self.slices.push_borrowed(iov);
+            self.optimize();
+        }
+    }
+
+    /// Schedules `anchor` to be dropped once all the currently
+    /// buffered slices are consumed.
+    #[inline(always)]
+    pub fn push_anchor(&mut self, anchor: Anchor) {
+        self.slices.push_anchor(anchor);
+    }
+
+    /// Registers a backreference at the current write location, with
+    /// the `pattern`'s size.
+    pub fn register_patch(&mut self, pattern: &[u8]) -> Backref {
+        if pattern.is_empty() {
+            let ret = Backref(None);
+            assert!(ret.is_empty());
+            return ret;
+        }
+
+        // XXX: this assumes the optimisation process only tries to merge
+        // the most recently pushed slice with the immediately preceding one.
+        self.push_copy(pattern);
+        assert!(!self.is_empty());
+
+        let pattern_size = pattern.len();
+        let logical_index = self.slices.logical_size() - (pattern_size as u64);
+        let info = BackrefInfo {
+            slice_index: self.slices.last_logical_slice_index(),
+            begin: ioslice_len(self.slices.last_slice().unwrap()) - pattern_size,
+            len: NonZeroUsize::try_from(pattern_size).unwrap(), // We checked for emptiness above
+        };
+        self.backrefs
+            .push_back_or_panic((logical_index, Some(info)));
+        let ret = Backref(Some((logical_index, info)));
+        assert!(!ret.is_empty());
+        ret
+    }
+
+    /// Backpopulates a backreference created for this [`OwningIovec`].
+    ///
+    /// Panics if `src` does not match the backreference's size, or if
+    /// the backref does not come from the [`OwningIovec`].
+    pub fn backfill_or_panic(&mut self, backref: Backref, src: &[u8]) {
+        let (logical_index, info) = match backref.0 {
+            None => {
+                // Can only have empty backref.
+                assert_eq!(src, &[]);
+                return;
+            }
+            Some(backref) => backref,
+        };
+
+        assert_eq!(usize::from(info.len), src.len());
+        let backref_found_in_instance = self
+            .backrefs
+            .remove(&logical_index)
+            .expect("backref not found");
+        assert_eq!(backref_found_in_instance, (logical_index, Some(info)));
+
+        let target = self
+            .slices
+            .get_logical_slice(info.slice_index)
+            .expect("must still be present");
+        let (base, len) = ioslice::ioslice_components(target);
+
+        assert!(info.begin + src.len() <= len);
+        let dst = unsafe { base.add(info.begin) };
+        unsafe { std::ptr::copy(src.as_ptr(), dst, src.len()) };
+    }
+
+    /// Attempts to join together the last two slices in `self.iovs()`
+    /// if it's definitely safe to do so.  This method onl works on
+    /// the last two slices because we call it whenever a slice is
+    /// pushed to `self.iovs`.
+    #[inline(always)]
+    fn optimize(&mut self) {
+        self.slices
+            .maybe_collapse_last_pair(|left, right| unsafe { self.arena.try_join(left, right) });
+    }
+}
+
+// pure read methods
+impl OwningIovec<'_> {
+    /// Determines whether this [`OwningIovec`] currently has
+    /// backreferences in flight.
+    #[must_use]
+    #[inline(always)]
+    pub fn has_pending_backrefs(&self) -> bool {
+        !self.backrefs.is_empty()
+    }
+
+    /// Returns a prefix of the owned slices such that none of the
+    /// returned slices contain a backpatch.
+    #[must_use]
+    #[inline(always)]
+    pub fn stable_prefix(&self) -> &[IoSlice<'_>] {
+        // Unwrap because, if we have an element, its value is `Some`.
+        let stop_slice_index = self
+            .backrefs
+            .first()
+            .map(|backref| backref.1.unwrap().slice_index);
+        self.slices.get_logical_prefix(stop_slice_index)
+    }
+
+    /// Peeks at the next stable IoSlice
+    #[must_use]
+    #[inline(always)]
+    pub fn front(&self) -> Option<IoSlice<'_>> {
+        self.stable_prefix().first().copied()
+    }
+
+    /// The [`OwningIovec::iovs`] method is the only way to borrow
+    /// [`IoSlice`]s from an [`OwningIovec`]. The lifetime constraints
+    /// ensure that the return value outlives neither `this` nor `self`.
+    ///
+    /// Returns the stable prefix if some backrefs are still in flight.
+    #[inline(always)]
+    pub fn iovs(&self) -> Result<&[IoSlice<'_>], &[IoSlice<'_>]> {
+        let ret = self.stable_prefix();
+        if self.has_pending_backrefs() {
+            Err(ret)
+        } else {
+            Ok(ret)
+        }
+    }
+
+    /// Returns the number of slices in the [`OwningIovec`].
+    ///
+    /// This includes slices that are still waiting for a backpatch.
+    #[must_use]
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.slices.num_slices()
+    }
+
+    /// Determines whether the [`OwningIovec`] contains 0 slices.
+    #[must_use]
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the total number of bytes in `self.iovs`.
+    ///
+    /// This includes slices that are still waiting for a backpatch.
+    #[must_use]
+    #[inline(always)]
+    pub fn total_size(&self) -> usize {
+        self.slices.total_size()
+    }
+
+    /// Returns the contents of this iovec as a single [`Vec<u8>`].
+    ///
+    /// Returns the stable contents as an error if there is any backreference in flight.
+    #[inline(always)]
+    pub fn flatten(&self) -> Result<Vec<u8>, Vec<u8>> {
+        self.flatten_into(Vec::with_capacity(self.total_size()))
+    }
+
+    /// Appends the contents of this iovec so `dst`.
+    ///
+    /// Returns the stable contents as an error if there is any backreference in flight.
+    #[inline(always)]
+    pub fn flatten_into(&self, dst: Vec<u8>) -> Result<Vec<u8>, Vec<u8>> {
+        let ret = self.flatten_into_impl(dst);
+
+        if self.has_pending_backrefs() {
+            Err(ret)
+        } else {
+            Ok(ret)
+        }
+    }
+
+    #[must_use]
+    #[inline(never)]
+    fn flatten_into_impl(&self, mut dst: Vec<u8>) -> Vec<u8> {
+        dst.reserve(self.total_size());
+        for iov in self.stable_prefix() {
+            dst.extend_from_slice(iov);
+        }
+
+        dst
+    }
+}
+
+impl<'a> ConsumingIovec<'a> {
+    /// Returns a reference to the underlying arena.
+    #[must_use]
+    #[inline(always)]
+    pub fn arena(&mut self) -> &mut ByteArena {
+        &mut self.iovec().arena
+    }
+
+    /// Returns the underlying arena and replaces it with a new
+    /// default-constructed arena.
+    #[must_use]
+    pub fn take_arena(&mut self) -> ByteArena {
+        self.swap_arena(Default::default())
+    }
+
+    /// Replaces the underlying arena with the argument and returns
+    /// the old underlying arena.
+    pub fn swap_arena(&mut self, mut arena: ByteArena) -> ByteArena {
+        std::mem::swap(&mut arena, self.arena());
+        arena
+    }
+
+    /// Pops the first [`IoSlice`].  Panics if the [`OwningIovec`] has no stable prefix.
+    #[inline(always)]
+    pub fn pop_front(&mut self) {
+        let consumed = self.consume(1);
+        assert_eq!(consumed, 1);
+    }
+
+    /// Pops up to the next `count` [`IoSlice`]s returned by [`OwningIovec::stable_prefix`].
+    ///
+    /// Returns the number of slices consumed.
+    #[inline(always)]
+    pub fn consume(&mut self, count: usize) -> usize {
+        let num_slices = self.stable_prefix().len();
+        self.iovec().slices.consume(count.min(num_slices))
+    }
+
+    /// Pops up to the next `count` bytes in the slices returned by [`OwningIovec::stable_prefix`].
+    ///
+    /// Returns the number of bytes consumed.
+    pub fn advance_slices(&mut self, count: usize) -> usize {
+        let mut stable_count = 0;
+        for slice in self.stable_prefix() {
+            let size = slice.len();
+            if size >= count - stable_count {
+                stable_count = count;
+                break;
+            }
+
+            stable_count += size;
+        }
+
+        self.iovec().slices.consume_by_bytes(stable_count)
+    }
+}
+
+impl StableIovec<'_> {
+    /// Returns the slices of bytes buffered in the underlying [`OwningIovec`].
+    #[must_use]
+    #[inline(always)]
+    pub fn iovs(&self) -> &[IoSlice<'_>] {
+        self.stable_prefix()
+    }
+
+    /// Returns a copy of the contents of the underlying [`OwningIovec`].
+    #[must_use]
+    #[inline(always)]
+    pub fn flatten(&self) -> Vec<u8> {
+        self.flatten_into(Vec::with_capacity(self.total_size()))
+    }
+
+    /// Appends a copy of the contents of the underlying [`OwningIovec`]
+    /// after `dst`.
+    #[must_use]
+    #[inline(always)]
+    pub fn flatten_into(&self, dst: Vec<u8>) -> Vec<u8> {
+        self.flatten_into_impl(dst)
+    }
+}
+
+impl<'life> IntoIterator for &'life OwningIovec<'_> {
+    type Item = &'life IoSlice<'life>;
+    type IntoIter = std::slice::Iter<'life, IoSlice<'life>>;
+
+    fn into_iter(self) -> std::slice::Iter<'life, IoSlice<'life>> {
+        self.stable_prefix().iter()
+    }
+}
+
+impl<'life> FromIterator<IoSlice<'life>> for OwningIovec<'life> {
+    fn from_iter<T: IntoIterator<Item = IoSlice<'life>>>(iter: T) -> OwningIovec<'life> {
+        let slices: Vec<IoSlice<'life>> = iter.into_iter().collect();
+
+        OwningIovec::new_from_slices(slices, None)
+    }
+}
+
+impl<'life> FromIterator<&'life IoSlice<'life>> for OwningIovec<'life> {
+    #[inline(always)]
+    fn from_iter<T: IntoIterator<Item = &'life IoSlice<'life>>>(iter: T) -> OwningIovec<'life> {
+        OwningIovec::from_iter(iter.into_iter().copied())
+    }
+}
+
+// Exercise simple iovec optimisation
+#[test]
+fn test_happy_optimize_miri() {
+    use std::io::Write;
+
+    let mut iovs: OwningIovec = vec![&b""[..]].into_iter().map(IoSlice::new).collect();
+
+    // We don't do anything for zero-sized slices
+    iovs.push_borrowed(b"");
+    iovs.push_copy(b"");
+    iovs.push(b"");
+    assert!(iovs.is_empty());
+
+    // Push small slices
+    iovs.push_borrowed(b"000");
+
+    // Copy a bunch of slices that can be concatenated in place.
+    iovs.arena().ensure_capacity(10);
+    iovs.push_copy(b"123");
+    iovs.arena().ensure_capacity(7);
+    iovs.push_copy(b"456");
+    iovs.push(b"7");
+    iovs.push_borrowed(b"aaa");
+    iovs.push_anchor(Default::default());
+
+    // We expect 3 ioslices:
+    // 1 for the initial `push_borrowed`,
+    // 1 for the "123", "456", then "7" (optimised as copy)
+    // 1 for the final `push_borrowed`
+    assert_eq!(iovs.len(), 3);
+    assert_eq!(iovs.total_size(), 13);
+
+    let mut dst = Vec::new();
+    assert_eq!(
+        dst.write_vectored(iovs.iovs().unwrap())
+            .expect("must_succeed"),
+        13
+    );
+
+    assert_eq!(dst, b"0001234567aaa");
+
+    // now consume 4 bytes.
+    assert_eq!(iovs.consumer().advance_slices(4), 4);
+    assert_eq!(iovs.len(), 2);
+    assert_eq!(iovs.total_size(), 9);
+
+    assert_eq!(iovs.flatten().unwrap(), b"234567aaa");
+
+    assert_eq!(
+        iovs.stable_consumer()
+            .expect("no backref")
+            .advance_slices(100),
+        9
+    );
+    assert!(iovs.is_empty());
+    assert_eq!(iovs.len(), 0);
+    assert_eq!(iovs.total_size(), 0);
+    assert_eq!(iovs.stable_consumer().unwrap().flatten(), b"");
+
+    assert_eq!(iovs.consumer().advance_slices(100), 0);
+    assert_eq!(iovs.flatten().unwrap(), b"");
+}
+
+// Make sure we don't optimize when there's a gap.
+#[test]
+fn test_no_optimize_gap_miri() {
+    let slices = [IoSlice::new(&b""[..])];
+    let mut iovs: OwningIovec = slices.iter().collect();
+
+    iovs.push_borrowed(b"000");
+    iovs.push_copy(b"123");
+    // Create a gap in the copied allocations.
+    let _ = unsafe { iovs.arena.copy(b"xxx", None) };
+    iovs.push_copy(b"456");
+    iovs.push_borrowed(b"aaa");
+
+    // Force a realloc, make sure this doesn't do weird stuff.
+    let mut arena = iovs.consumer().take_arena();
+    arena.ensure_capacity(10000);
+    iovs.consumer().swap_arena(arena);
+
+    assert_eq!(iovs.len(), 4);
+    assert_eq!(iovs.total_size(), 12);
+
+    assert_eq!(iovs.flatten_into(vec![0x42]).unwrap(), b"\x42000123456aaa");
+}
+
+// Make sure we *don't* optimize when the arena's cache
+// is reused for another `OwningIovec`.
+#[test]
+fn test_no_optimize_flush_miri() {
+    let mut iovs = OwningIovec::new();
+
+    iovs.push_borrowed(b"000");
+    iovs.push_copy(b"123");
+
+    // Mess with the cached allocation
+    iovs.arena().flush_cache();
+    iovs.clone().push_copy(b"123");
+
+    // Shouldn't merge with the previous.
+    iovs.push_copy(b"456");
+    iovs.push_borrowed(b"aaa");
+
+    assert_eq!(iovs.len(), 4);
+    assert_eq!(iovs.total_size(), 12);
+
+    assert_eq!(iovs.flatten().unwrap(), b"000123456aaa");
+}
+
+// Exercise the `extend` method.
+#[test]
+fn test_extend_miri() {
+    use std::io::Write;
+
+    let mut iovs2 = OwningIovec::new();
+    let mut iovs = OwningIovec::new();
+
+    iovs.push_borrowed(b"000");
+    iovs2.push_copy(b"123");
+    iovs2.push_copy(b"456");
+    iovs.extend(iovs2.into_iter().copied());
+
+    // We don't expect empty slices, but we should still drop them on
+    // the floot.
+    iovs.extend([IoSlice::new(&[0u8][..0]), IoSlice::new(&[0u8])]);
+    iovs.push_borrowed(b"aaa");
+
+    assert_eq!(iovs.len(), 4);
+    assert_eq!(iovs.total_size(), 13);
+
+    let mut dst = Vec::new();
+    assert_eq!(
+        dst.write_vectored(iovs.stable_consumer().unwrap().iovs())
+            .expect("must_succeed"),
+        13
+    );
+
+    assert_eq!(dst, b"000123456\x00aaa");
+}
+
+// Make sure we can reuse arenas for multiple OwningIovec
+#[test]
+fn test_inherit_miri() {
+    use std::io::Write;
+
+    let mut iovs2 = OwningIovec::new();
+    let mut iovs = OwningIovec::new();
+
+    iovs.push(b"000");
+    iovs2.push_copy(b"123");
+    iovs2.push_copy(b"456");
+    iovs.extend(iovs2.into_iter().copied());
+    iovs.push(b"aaa");
+
+    assert!(iovs.len() <= 3);
+    assert_eq!(iovs.total_size(), 12);
+
+    let mut dst = Vec::new();
+    assert_eq!(
+        dst.write_vectored(iovs.iovs().unwrap())
+            .expect("must_succeed"),
+        12
+    );
+
+    assert_eq!(dst, b"000123456aaa");
+}
+
+// Make sure we can steal another iov's arena
+#[test]
+fn test_inherit2_miri() {
+    use std::io::Write;
+
+    let mut iovs2;
+    let mut iovs = OwningIovec::new();
+
+    iovs.push(b"000");
+    iovs2 = OwningIovec::new_from_arena(iovs.consumer().take_arena());
+    iovs2.push_copy(b"123");
+    iovs2.push_copy(b"456");
+    iovs.extend(iovs2.iovs().unwrap().iter().copied());
+    iovs.push(b"aaa");
+
+    assert!(iovs.len() <= 3);
+    assert_eq!(iovs.total_size(), 12);
+
+    let mut dst = Vec::new();
+    assert_eq!(
+        dst.write_vectored(iovs.iovs().unwrap())
+            .expect("must_succeed"),
+        12
+    );
+
+    assert_eq!(dst, b"000123456aaa");
+}
+
+// Make sure we merge a 128-byte `push` with the previous owned slice.
+#[test]
+fn test_medium_write_merge_miri() {
+    use std::io::Write;
+
+    let mut iovs = OwningIovec::new();
+
+    iovs.push_copy(&[1u8; 3]);
+    iovs.push(&[1u8; 128]);
+
+    assert_eq!(iovs.len(), 1);
+    assert_eq!(iovs.total_size(), 131);
+
+    let mut dst = Vec::new();
+    assert_eq!(
+        dst.write_vectored(iovs.iovs().unwrap())
+            .expect("must_succeed"),
+        131
+    );
+
+    assert_eq!(dst, [1u8; 131]);
+}
+
+// Make sure we gracefully handle the case where the final copy doesn't fit in the
+// the previous copy's arena, so can't be merged.
+#[test]
+fn test_medium_write_disjoint_miri() {
+    use std::io::Write;
+
+    let mut iovs = OwningIovec::new_from_slices(vec![IoSlice::new(&[1u8; 3])], None);
+    iovs.push_copy(&[1u8; 128]);
+    iovs.arena().flush_cache();
+    iovs.push_copy(&[1u8; 4096]);
+
+    assert_eq!(iovs.len(), 3);
+    assert_eq!(iovs.total_size(), 3 + 128 + 4096);
+
+    let mut dst = Vec::new();
+    assert_eq!(
+        dst.write_vectored(iovs.iovs().unwrap())
+            .expect("must_succeed"),
+        3 + 128 + 4096
+    );
+
+    assert_eq!(dst, [1u8; 3 + 128 + 4096]);
+}
+
+// `push` should borrow for larger slices.
+#[test]
+fn test_large_write_miri() {
+    use std::io::Write;
+
+    let mut iovs = OwningIovec::new();
+
+    iovs.push_copy(&[1u8; 3]);
+    iovs.push(&[1u8; 1024]);
+    iovs.push_copy(&[1u8; 4093]);
+    iovs.arena().flush_cache();
+
+    assert_eq!(iovs.len(), 3);
+    assert_eq!(iovs.total_size(), 3 + 1024 + 4093);
+
+    let mut dst = Vec::new();
+    assert_eq!(
+        dst.write_vectored(iovs.iovs().unwrap())
+            .expect("must_succeed"),
+        3 + 1024 + 4093
+    );
+
+    assert_eq!(dst, [1u8; 3 + 1024 + 4093]);
+}
+
+// Backref happy path
+#[test]
+fn test_backref_miri() {
+    let mut iovs = OwningIovec::new();
+
+    // Special safe case: empty patch.
+    let empty = iovs.register_patch(&[]);
+
+    assert!(iovs.iovs().is_ok());
+
+    let backref = iovs.register_patch(&[0u8]);
+    iovs.push(b"123");
+    let other_backref = iovs.register_patch(&[0u8; 2]);
+    iovs.push(b"56789");
+
+    assert!(iovs.front().is_none());
+    assert!(iovs.stable_consumer().is_err());
+    assert!(iovs.iovs().is_err());
+
+    iovs.backfill_or_panic(backref, b"a");
+    assert!(iovs.iovs().is_err());
+    assert!(iovs.flatten().is_err());
+    assert!(iovs.front().is_none());
+
+    iovs.backfill_or_panic(other_backref, b"bb");
+
+    assert!(iovs.iovs().is_ok());
+    assert!(iovs.front().is_some());
+    assert_eq!(&*iovs.front().unwrap(), b"a123bb56789");
+
+    assert_eq!(iovs.flatten().unwrap(), b"a123bb56789");
+
+    iovs.backfill_or_panic(empty, b"");
+    assert_eq!(iovs.flatten().unwrap(), b"a123bb56789");
+
+    iovs.consumer().pop_front();
+
+    assert!(iovs.is_empty());
+}
+
+// Make sure we still do the right thing when slices around the backref are borrowed.
+#[test]
+fn test_backref_borrowed_miri() {
+    let mut iovs = OwningIovec::new();
+
+    let backref = iovs.register_patch(&[0u8]);
+    iovs.push_borrowed(b"123");
+    let other_backref = iovs.register_patch(&[0u8; 2]);
+    iovs.push(b"56789");
+
+    assert!(iovs.iovs().is_err());
+
+    iovs.backfill_or_panic(backref, b"a");
+    assert!(iovs.iovs().is_err());
+    // We can read the first slice now.
+    assert_eq!(&*iovs.front().unwrap(), b"a");
+
+    iovs.backfill_or_panic(other_backref, b"bb");
+
+    assert!(iovs.iovs().is_ok());
+
+    assert_eq!(iovs.flatten().unwrap(), b"a123bb56789");
+}
+
+// Make sure we still do the right thing when slices around the backref are borrowed.
+#[test]
+fn test_backref_borrowed2_miri() {
+    let mut iovs = OwningIovec::new();
+
+    let backref = iovs.register_patch(&[0u8]);
+    iovs.push(b"123");
+    let other_backref = iovs.register_patch(&[0u8; 2]);
+    iovs.push_borrowed(b"56789");
+
+    assert!(iovs.iovs().is_err());
+
+    iovs.backfill_or_panic(backref, b"a");
+    assert!(iovs.iovs().is_err());
+    assert!(iovs.front().is_none()); // still waiting for the second backref
+
+    iovs.backfill_or_panic(other_backref, b"bb");
+    assert_eq!(&*iovs.front().unwrap(), b"a123bb");
+
+    assert!(iovs.iovs().is_ok());
+
+    assert_eq!(iovs.flatten().unwrap(), b"a123bb56789");
+}
+
+// Make sure we still do the right thing when all slices around the backref are borrowed.
+#[test]
+fn test_backref_all_borrowed_miri() {
+    let mut iovs = OwningIovec::new();
+
+    let backref = iovs.register_patch(&[0u8]);
+    iovs.push_borrowed(b"123");
+    let other_backref = iovs.register_patch(&[0u8; 2]);
+    iovs.push_borrowed(b"56789");
+
+    assert!(iovs.iovs().is_err());
+
+    iovs.backfill_or_panic(backref, b"a");
+    assert!(iovs.iovs().is_err());
+    assert_eq!(&*iovs.front().unwrap(), b"a");
+
+    iovs.backfill_or_panic(other_backref, b"bb");
+
+    assert!(iovs.iovs().is_ok());
+
+    assert_eq!(iovs.flatten().unwrap(), b"a123bb56789");
+
+    assert_eq!(&*iovs.front().unwrap(), b"a");
+    iovs.consumer().pop_front();
+    assert_eq!(&*iovs.front().unwrap(), b"123");
+    iovs.consumer().pop_front();
+
+    assert_eq!(iovs.len(), 2);
+    assert_eq!(iovs.total_size(), 2 + 5);
+
+    assert_eq!(iovs.flatten().unwrap(), b"bb56789");
+}

--- a/owning_iovec/src/ioslice.rs
+++ b/owning_iovec/src/ioslice.rs
@@ -1,0 +1,109 @@
+//! Use the backing foreign type to manipulate [`IoSlice`]s without converting
+//! back to regular slices: the conversion to slices introduces stacked borrow
+//! constraints.
+#[cfg(unix)]
+mod unix {
+    use std::io::IoSlice;
+
+    const _: () =
+        assert!(std::mem::size_of::<libc::iovec>() == std::mem::size_of::<IoSlice<'static>>());
+
+    /// Creates an `IoSlice<'static>` from a raw pointer and length.
+    ///
+    /// # Safety
+    ///
+    /// The `'static` lifetime is a lie; the caller must ensure that the
+    /// memory region pointed to by `base` with length `len` is valid for the
+    /// lifetime of the returned `IoSlice`.
+    #[must_use]
+    #[inline]
+    pub fn make_ioslice(base: *mut u8, len: usize) -> IoSlice<'static> {
+        let ret = libc::iovec {
+            iov_base: base as *mut _,
+            iov_len: len,
+        };
+
+        unsafe { std::mem::transmute(ret) }
+    }
+
+    /// Returns the base pointer and length of the given `IoSlice<'_>`.
+    #[must_use]
+    #[inline]
+    pub fn ioslice_components(slice: IoSlice<'_>) -> (*mut u8, usize) {
+        let ret: libc::iovec = unsafe { std::mem::transmute(slice) };
+
+        (ret.iov_base as *mut u8, ret.iov_len)
+    }
+}
+
+#[cfg(unix)]
+pub use unix::{ioslice_components, make_ioslice};
+
+#[allow(unused)]
+mod windows {
+    use std::io::IoSlice;
+
+    // https://learn.microsoft.com/en-us/windows/win32/api/ws2def/ns-ws2def-wsabuf
+    //
+    // typedef struct _WSABUF {
+    //   ULONG len;
+    //   CHAR  *buf;
+    // } WSABUF, *LPWSABUF;
+    struct WSABuf {
+        len: u32, // Windows is LLP64, so ULONG is 32 bits.
+        buf: *mut u8,
+    }
+
+    const _: () = assert!(std::mem::size_of::<WSABuf>() == std::mem::size_of::<IoSlice<'static>>());
+
+    /// Creates an `IoSlice<'static>` from a raw pointer and length.
+    ///
+    /// # Safety
+    ///
+    /// The `'static` lifetime is a lie; the caller must ensure that the
+    /// memory region pointed to by `base` with length `len` is valid for the
+    /// lifetime of the returned `IoSlice`.
+    #[must_use]
+    #[inline]
+    pub fn make_ioslice(base: *mut u8, len: usize) -> IoSlice<'static> {
+        let ret = WSABuf {
+            len: len
+                .try_into()
+                .expect("ioslice must not exceed 4 GB on windows"),
+            buf: base,
+        };
+
+        unsafe { std::mem::transmute(ret) }
+    }
+
+    /// Returns the base pointer and length of the given `IoSlice<'_>`.
+    #[must_use]
+    #[inline]
+    pub fn ioslice_components(slice: IoSlice<'_>) -> (*mut u8, usize) {
+        let ret: WSABuf = unsafe { std::mem::transmute(slice) };
+
+        (ret.buf, ret.len as usize)
+    }
+}
+
+#[cfg(windows)]
+pub use windows::{ioslice_components, make_ioslice};
+
+#[test]
+fn test_roundtrip_miri() {
+    use std::io::IoSlice;
+
+    let data = vec![1, 2, 3];
+    let slice = IoSlice::new(&data);
+
+    let (base, len) = ioslice_components(slice);
+    assert_eq!(base as *const u8, data.as_ptr_range().start);
+    assert_eq!(len, data.len());
+
+    let new_slice = make_ioslice(base, len);
+    assert_eq!(&*slice, &*new_slice);
+    assert_eq!(slice.as_ptr(), new_slice.as_ptr());
+    assert_eq!(slice.len(), new_slice.len());
+
+    assert_eq!(ioslice_components(slice), ioslice_components(new_slice))
+}

--- a/owning_iovec/src/lib.rs
+++ b/owning_iovec/src/lib.rs
@@ -1,0 +1,86 @@
+//! The `owning_iovec` crate exposes an [`OwningIovec`] object that
+//! supports on-the-fly production and consumption of bytes (i.e.,
+//! like an in-memory pipe), along with supporting machinery.  Unlike
+//! classical pipes or buffers, the [`OwningIovec`] works in terms
+//! of slices, some of which may be borrowed without a byte copy.
+//!
+//! An [`OwningIovec`] may also own slices; the allocations that back
+//! owned slices are tracked internally and released as the slices are
+//! consumed.
+//!
+//! For producers, the [`OwningIovec`] also supports backreferences:
+//! rather than each producer having to implement its own buffering,
+//! producers may now pre-allocate mutable slices, and backfill them
+//! after the fact.  On-the-fly consumption will be blocked from
+//! consuming slices while the backpatch is still pending.
+//!
+//! Consumers get an *asymptotic* on-the-fly consumption: there is no
+//! guarantee that consumers can read a steady flow of bytes, even
+//! when their producer generates bytes.  The guarantee is rather that
+//! the amount of bytes buffered in an `[OwningIovec`] is bounded,
+//! as a constant multiple of the largest slices lent to the [`OwningIovec`].
+//!
+//! Producers work with [`OwningIovec`], [`Backref`], and
+//! [`AnchoredSlice`] (produced by [`ByteArena`]).
+//!
+//! Consumers handle [`ConsumingIovec`] or, if they must know that the
+//! producer does not have any backreference in flight, [`StableIovec`].
+mod byte_arena;
+mod global_deque;
+mod implementation;
+mod ioslice;
+
+pub use byte_arena::AnchoredSlice;
+pub use byte_arena::ByteArena;
+pub use implementation::Backref;
+pub use implementation::ConsumingIovec;
+pub use implementation::OwningIovec;
+pub use implementation::StableIovec;
+
+impl std::io::Read for ConsumingIovec<'_> {
+    fn read(&mut self, mut dst: &mut [u8]) -> std::io::Result<usize> {
+        let mut written = 0;
+        while !dst.is_empty() {
+            let Some(slice) = self.front() else {
+                break;
+            };
+
+            let to_write = slice.len().min(dst.len());
+            dst[..to_write].copy_from_slice(&slice[..to_write]);
+            self.advance_slices(to_write);
+            written += to_write;
+            dst = &mut dst[to_write..];
+        }
+
+        Ok(written)
+    }
+}
+
+#[test]
+fn test_read() {
+    use std::io::Read;
+
+    let mut iovec = OwningIovec::new();
+    iovec.push_copy(b"123");
+    iovec.push(b"456");
+
+    let mut dst = Vec::new();
+    iovec
+        .consumer()
+        .read_to_end(&mut dst)
+        .expect("should succeed");
+    assert_eq!(dst, b"123456");
+}
+
+#[test]
+fn test_read_short() {
+    use std::io::Read;
+
+    let mut iovec = OwningIovec::new();
+    iovec.push_copy(b"123");
+    iovec.push(b"456");
+
+    let mut dst = [0u8; 4];
+    assert_eq!(iovec.consumer().read(&mut dst).expect("should succeed"), 4);
+    assert_eq!(&dst, b"1234");
+}

--- a/vouched_time/Cargo.toml
+++ b/vouched_time/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "vouched_time"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+raffle = "0.0.1"
+# https://users.rust-lang.org/t/the-state-of-time-in-rust-leaps-and-bounds/107620
+# we only need UTC, and don't really care what happens with leap seconds.
+time = "0.3"
+
+[dev-dependencies]
+time = { version = "0.3", features = ["macros"]}
+test_dir = "0.2"
+
+[lints]
+workspace = true

--- a/vouched_time/src/atomic_base_time.rs
+++ b/vouched_time/src/atomic_base_time.rs
@@ -1,0 +1,231 @@
+//! Implement a lock-free pair of base_time_ms and corresponding voucher
+//! with two copies and a sequence number.
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Mutex;
+
+#[derive(Debug)]
+struct BaseTime {
+    base_time_ms: AtomicU64,
+    voucher: AtomicU64,
+}
+
+#[derive(Debug)]
+struct WriteToken {}
+
+/// An [`AtomicBaseTime`] is a lock-free pair of `base_time_ms` and
+/// corresponding voucher.
+///
+/// Internally, it's implemented as a sequence number and two copies.
+/// At any one time, the copy at `sequence % len` is stable (not being
+/// written).  A read is valid if the sequence didn't change mid-snapshot.
+#[derive(Debug)]
+pub struct AtomicBaseTime {
+    lock: Mutex<WriteToken>,
+    // The snapshot at sequence % len is stable; the next one may be mid-update.
+    sequence: AtomicU64,
+    snapshots: [BaseTime; 2],
+}
+
+impl Default for AtomicBaseTime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+const _: () = assert!(std::mem::size_of::<raffle::Voucher>() == std::mem::size_of::<u64>());
+
+union TransmuteVoucher {
+    bits: u64,
+    voucher: raffle::Voucher,
+}
+
+impl BaseTime {
+    /// Returns a new `BaseTime` initialised for the epoch.
+    const fn new() -> Self {
+        const VOUCH_PARAMS: raffle::VouchingParameters = raffle::VouchingParameters::parse_or_die(
+            "VOUCH-773ec2a0e62c20cd-f9e079b78e895091-fc1da7b1b77c57cb-594b9cce3091464a",
+        );
+
+        let base_time_ms = 0u64;
+        let voucher = VOUCH_PARAMS.vouch(base_time_ms);
+        let voucher = unsafe { TransmuteVoucher { voucher }.bits };
+        Self {
+            base_time_ms: AtomicU64::new(base_time_ms),
+            voucher: AtomicU64::new(voucher),
+        }
+    }
+
+    /// Updates the internal value with release stores.
+    ///
+    /// The voucher must match base_time_ms.
+    pub fn update(&self, base_time_ms: u64, voucher: raffle::Voucher) {
+        assert!(crate::BASE_TIME_CHECK.check(base_time_ms, voucher));
+
+        self.base_time_ms.store(base_time_ms, Ordering::Release);
+        self.voucher.store(
+            unsafe { TransmuteVoucher { voucher }.bits },
+            Ordering::Release,
+        );
+    }
+
+    /// Returns a snapshot of the current pair.
+    ///
+    /// The snapshot may be invalid when executed concurrently with an update.
+    pub fn snapshot(&self) -> (u64, u64) {
+        let bits = self.voucher.load(Ordering::Acquire);
+        let base_time_ms = self.base_time_ms.load(Ordering::Acquire);
+
+        // Can't check here because we might have a racy update.
+        (base_time_ms, bits)
+    }
+}
+
+impl AtomicBaseTime {
+    /// Returns a new `AtomicBaseTime` instance initialised at the epoch.
+    pub const fn new() -> Self {
+        Self {
+            lock: Mutex::new(WriteToken {}),
+            sequence: AtomicU64::new(0),
+            snapshots: [BaseTime::new(), BaseTime::new()],
+        }
+    }
+
+    /// Returns the current sequence number.
+    pub fn sequence(&self) -> u64 {
+        self.sequence.load(Ordering::Relaxed)
+    }
+
+    /// Lock-freely takes a consistent snapshot of the `AtomicBaseTime`.
+    ///
+    /// The return value corresponds to the most recent `update`d pair
+    /// on entry, or one of the values `update`d between entry and exit.
+    pub fn snapshot(&self) -> (u64, raffle::Voucher) {
+        let mut sequence = self.sequence.load(Ordering::Acquire);
+
+        loop {
+            let (base_time_ms, bits) =
+                self.snapshots[(sequence as usize) % self.snapshots.len()].snapshot();
+            let next_sequence = self.sequence.load(Ordering::Acquire);
+            if sequence == next_sequence {
+                // We got a good read, transmute!
+                //
+                // It would be safe to transmute earlier, since each 64-bit
+                // load is atomic, but this is the general pattern.
+                let voucher = unsafe { TransmuteVoucher { bits }.voucher };
+                assert!(crate::BASE_TIME_CHECK.check(base_time_ms, voucher));
+
+                return (base_time_ms, voucher);
+            }
+
+            sequence = next_sequence;
+        }
+    }
+
+    /// Updates the value stored in the `AtomicBaseTime`.
+    ///
+    /// Calls serialise on an internal lock, but do not block
+    /// `snapshot` calls.
+    pub fn update(&self, update: (u64, raffle::Voucher)) {
+        let mut token = loop {
+            match self.lock.lock() {
+                Ok(guard) => break guard,
+                // The lock only serves for mutual exclusion, if it's
+                // poisoned, the previous holder isn't updating.
+                Err(_) => self.lock.clear_poison(),
+            }
+        };
+
+        self.advance_once(&mut token, update);
+    }
+
+    /// Wait-free attempt at updating the value stored in the `AtomicBaseTime`.
+    ///
+    /// Returns whether the instance was updated.
+    ///
+    /// Calls still serialise on an internal lock, but they return `false`
+    /// instead of blocking.
+    pub fn try_update(&self, update: (u64, raffle::Voucher)) -> bool {
+        use std::sync::TryLockError::*;
+
+        let mut token = match self.lock.try_lock() {
+            Ok(guard) => guard,
+            Err(Poisoned(_)) => {
+                self.lock.clear_poison();
+                return false;
+            }
+            Err(WouldBlock) => return false,
+        };
+
+        self.advance_once(&mut token, update)
+    }
+
+    fn advance_once(&self, _token: &mut WriteToken, update: (u64, raffle::Voucher)) -> bool {
+        let current = self.sequence.load(Ordering::Relaxed);
+        let current_base_time_ms = self.snapshots[(current as usize) % self.snapshots.len()]
+            .snapshot()
+            .0;
+        if update.0 < current_base_time_ms {
+            // The update is older than the current value; skip it.
+            return false;
+        }
+
+        let next = current.wrapping_add(1);
+        let idx = (next as usize) % self.snapshots.len();
+
+        self.snapshots[idx].update(update.0, update.1);
+        self.sequence.store(next, Ordering::Release); // Commit the write
+        true
+    }
+}
+
+// Make sure this works.
+#[cfg(test)]
+static _BASE_TIME: AtomicBaseTime = AtomicBaseTime::new();
+
+#[test]
+fn test_smoke_miri() {
+    const VOUCH_PARAMS: raffle::VouchingParameters = raffle::VouchingParameters::parse_or_die(
+        "VOUCH-773ec2a0e62c20cd-f9e079b78e895091-fc1da7b1b77c57cb-594b9cce3091464a",
+    );
+
+    let base_time: AtomicBaseTime = Default::default();
+    assert_eq!(base_time.sequence(), 0);
+
+    assert_eq!(base_time.snapshot().0, 0);
+
+    {
+        let (time, voucher) = base_time.snapshot();
+        assert!(VOUCH_PARAMS.checking_parameters().check(time, voucher));
+    }
+
+    base_time.update((42, VOUCH_PARAMS.vouch(42)));
+    assert_eq!(base_time.sequence(), 1);
+
+    assert_eq!(base_time.snapshot().0, 42);
+    {
+        let (time, voucher) = base_time.snapshot();
+        assert!(VOUCH_PARAMS.checking_parameters().check(time, voucher));
+    }
+
+    base_time.try_update((100, VOUCH_PARAMS.vouch(100)));
+    assert_eq!(base_time.sequence(), 2);
+
+    assert_eq!(base_time.snapshot().0, 100);
+    {
+        let (time, voucher) = base_time.snapshot();
+        assert!(VOUCH_PARAMS.checking_parameters().check(time, voucher));
+    }
+}
+
+#[test]
+#[should_panic(expected = "BASE_TIME_CHECK.check")]
+fn test_panic_miri() {
+    const VOUCH_PARAMS: raffle::VouchingParameters = raffle::VouchingParameters::parse_or_die(
+        "VOUCH-773ec2a0e62c20cd-f9e079b78e895091-fc1da7b1b77c57cb-594b9cce3091464a",
+    );
+
+    let base_time = AtomicBaseTime::new();
+
+    base_time.update((42, VOUCH_PARAMS.vouch(43)));
+}

--- a/vouched_time/src/lib.rs
+++ b/vouched_time/src/lib.rs
@@ -1,0 +1,427 @@
+//! The `vouched_time` crate exposes the [`VouchedTime`] type, a wrapper
+//! around a trusted base time, a [`raffle::Voucher`] as a weak witness that
+//! the base time deserves our trust, and a presumably more up-to-date
+//! [`time::PrimitiveDateTime`] local time.
+//!
+//! It is meant to help time-based logic systems detect innocent bugs in time
+//! handling, especially in protocols where when generating times far in the
+//! future can result in hard to debug issues.
+//!
+//! The source of trusted base times could be a [Roughtime
+//! server](https://datatracker.ietf.org/doc/draft-ietf-ntp-roughtime/), or a
+//! local [ClockBound](https://github.com/aws/clock-bound) daemon (neither
+//! option is implemented yet).
+//!
+//! For now the only trusted base time source is a trusted filesystem's ctimes
+//!([`nfs_voucher`]): we want to use vouched times in a library that exchanges
+//! messages over NFS, so it makes sense to assume everyone can access the NFS
+//! server.
+mod atomic_base_time;
+pub mod nfs_voucher;
+
+use std::io::Result;
+
+#[cfg(test)]
+use time::macros::datetime;
+
+pub use atomic_base_time::AtomicBaseTime;
+
+/// We allow times that are at most slightly less than 3 seconds (3000
+/// ms) ahead of the vouched time.  This tolerance is relatively tight
+/// because it's important to avoid time travel from the future.
+///
+/// The value is slightly less than 3000 ms to account for rounding,
+/// truncation, and off-by-ones.
+pub const MAX_FORWARD_DISCREPANCY_MS: u64 = 2990;
+
+/// We allow times that are most slightly less than 60 seconds (60 000 ms)
+/// behind the vouched time.  This tolerance is loose because asynchronous
+/// systems fundamentally have to deal with slow peers, and because a program
+/// could always keep using a stale base time.
+///
+/// The value is slightly less than 60 000 ms to account for rounding,
+/// truncation, and off-by-ones.
+pub const MAX_BACKWARD_DISCREPANCY_MS: u64 = 59_900;
+
+// Generated with `generate_raffle_parameters "woodpile vouched time"`
+const BASE_TIME_CHECK: raffle::CheckingParameters =
+    raffle::CheckingParameters::parse_or_die("CHECK-fc1da7b1b77c57cb-594b9cce3091464a");
+
+/// A [`VouchedTime`] is the combination of a local [`time::PrimitiveDateTime`]
+/// in UTC, and a [`raffle::Voucher`] for a [`u64`] base time (milliseconds since
+/// Unix epoch) such that the local time is at most
+/// [`MAX_BACKWARD_DISCREPANCY_MS`] behind the base time or
+/// [`MAX_FORWARD_DISCREPANCY_MS`] ahead of the base time.  Once a
+/// [`VouchedTime`] is constructed with a trusted base time, we assume it's not
+/// (deliberately) too far in the future, and likely not too far in the past
+/// either.
+///
+/// In this crate, the term "local time" refers to each machine's
+/// approximation of UTC.
+#[derive(Clone, Copy, Debug)]
+pub struct VouchedTime {
+    local_time: time::PrimitiveDateTime,
+    base_time_ms: u64,
+    voucher: raffle::Voucher,
+}
+
+impl VouchedTime {
+    /// Constructs a new VouchedTime, or returns a reason why it's invalid.
+    ///
+    /// This only errors out when something's really wrong; consider using
+    /// [`VouchedTime::new_or_die`].
+    pub fn new(
+        local_time: time::PrimitiveDateTime,
+        base_time_ms: u64,
+        voucher: raffle::Voucher,
+    ) -> Result<VouchedTime> {
+        Self::check(local_time, base_time_ms, voucher)?;
+        let ret = VouchedTime {
+            local_time,
+            base_time_ms,
+            voucher,
+        };
+
+        ret.check_or_die();
+        Ok(ret)
+    }
+
+    /// Construct a new `VouchedTime` or dies trying.
+    pub fn new_or_die(
+        local_time: time::PrimitiveDateTime,
+        base_time_ms: u64,
+        voucher: raffle::Voucher,
+    ) -> VouchedTime {
+        VouchedTime::new(local_time, base_time_ms, voucher)
+            .expect("failed to construct VouchedTime")
+    }
+
+    /// Constructs a new VouchedTime based on the time returned by `base_time_provider`,
+    /// or returns a reason why the operation failed.
+    ///
+    /// This only errors out when something's really wrong (or the `base_time_provider`
+    /// errors out); consider using [`VouchedTime::now_or_die`].
+    pub fn now(
+        base_time_provider: impl FnOnce(time::OffsetDateTime) -> Result<(u64, raffle::Voucher)>,
+    ) -> Result<VouchedTime> {
+        let now = time::OffsetDateTime::now_utc();
+        let (base_time_ms, voucher) = base_time_provider(now)?;
+        VouchedTime::new(
+            time::PrimitiveDateTime::new(now.date(), now.time()),
+            base_time_ms,
+            voucher,
+        )
+    }
+
+    /// Returns a `VouchedTime` for the result of `base_time_provider` or dies trying.
+    pub fn now_or_die(
+        base_time_provider: impl FnOnce(time::OffsetDateTime) -> Result<(u64, raffle::Voucher)>,
+    ) -> VouchedTime {
+        VouchedTime::now(base_time_provider).expect("failed to construct VouchedTime")
+    }
+
+    /// Returns the local time stored in the `VouchedTime`.
+    pub fn get_local_time(self) -> time::PrimitiveDateTime {
+        self.check_or_die(); // Internal self-check before returning `local_time`.
+        self.local_time
+    }
+
+    /// Checks the internal representation for validity.  Panics
+    /// if anything's wrong: the constructors enforce the same conditions.
+    pub fn check_or_die(self) {
+        Self::check(self.local_time, self.base_time_ms, self.voucher)
+            .expect("Constructed VouchedTime should be valid");
+    }
+
+    /// Checks whether this `local_time` would be valid for `base_time_ms`
+    /// and the corresponding vouched.
+    pub fn check(
+        local_time: time::PrimitiveDateTime,
+        base_time_ms: u64,
+        voucher: raffle::Voucher,
+    ) -> Result<()> {
+        if !BASE_TIME_CHECK.check(base_time_ms, voucher) {
+            return Err(std::io::Error::other("base_time does not match voucher"));
+        }
+
+        Self::check_vouched_time(
+            local_time.assume_utc().unix_timestamp_nanos() / 1_000_000,
+            base_time_ms,
+        )
+    }
+
+    fn check_vouched_time(local_time_ms: i128, base_time_ms: u64) -> Result<()> {
+        let other = std::io::Error::other;
+
+        if local_time_ms < 0 {
+            return Err(other("local_time is before the Unix epoch"));
+        }
+
+        if local_time_ms > u64::MAX as i128 {
+            return Err(other("local time is out of range"));
+        }
+
+        let local_time_ms = local_time_ms as u64;
+        // if local_time - base_time in [-MAX_BACKWARD_DISCREPANCY_MS, MAX_FORWARD_DISCREPANCY_MS]
+        //
+        // We subtract base_time_ns, and add MAX_BACKWARD_DISCREPANCY_MS.  This maps the
+        // allowed range to `[0, MAX_BACKWARD_DISCREPANCY_MS + MAX_FORWARD_DISCREPANCY_MS]`.
+        if local_time_ms
+            .wrapping_sub(base_time_ms)
+            .wrapping_add(MAX_BACKWARD_DISCREPANCY_MS)
+            <= MAX_BACKWARD_DISCREPANCY_MS + MAX_FORWARD_DISCREPANCY_MS
+        {
+            return Ok(());
+        }
+
+        if local_time_ms > base_time_ms {
+            return Err(other("local_time is too far ahead of base_time"));
+        }
+
+        Err(other("local_time is too far behind base_time"))
+    }
+}
+
+// Check that we can construct `VouchedTime`s with an exact match on the base time.
+#[test]
+fn test_happy_path_miri() {
+    let vouch_params = raffle::VouchingParameters::parse_or_die(
+        "VOUCH-773ec2a0e62c20cd-f9e079b78e895091-fc1da7b1b77c57cb-594b9cce3091464a",
+    );
+
+    // $ date -u -d@1713027659
+    // Sat Apr 13 05:00:59 PM UTC 2024
+
+    assert_eq!(
+        VouchedTime::new_or_die(
+            datetime!(2024-04-13 17:00:59),
+            1713027659000,
+            vouch_params.vouch(1713027659000)
+        )
+        .get_local_time(),
+        datetime!(2024-04-13 17:00:59),
+    );
+
+    if !cfg!(miri) {
+        let now = |now: time::OffsetDateTime| {
+            let now = (now.unix_timestamp_nanos() / 1_000_000) as u64;
+            Ok((now, vouch_params.vouch(now)))
+        };
+
+        println!("{:?}", VouchedTime::now_or_die(now));
+        println!("{:?}", VouchedTime::now(now).expect("must succeed"));
+    }
+}
+
+// Go right at the end of the allowed discrepancy between the base time and the local time.
+#[test]
+fn test_limit_miri() {
+    let vouch_params = raffle::VouchingParameters::parse_or_die(
+        "VOUCH-773ec2a0e62c20cd-f9e079b78e895091-fc1da7b1b77c57cb-594b9cce3091464a",
+    );
+
+    // $ date -u -d@1713027659
+    // Sat Apr 13 05:00:59 PM UTC 2024
+
+    // Construct a time ahead of the vouched time
+    let time = VouchedTime::new(
+        datetime!(2024-04-13 17:01:01.990),
+        1713027659000,
+        vouch_params.vouch(1713027659000),
+    )
+    .expect("should build");
+    time.check_or_die();
+    assert_eq!(time.get_local_time(), datetime!(2024-04-13 17:01:01.99));
+
+    // One more millisecond, and it fails.
+    assert!(VouchedTime::new(
+        datetime!(2024-04-13 17:01:01.991),
+        1713027659000,
+        vouch_params.vouch(1713027659000),
+    )
+    .is_err());
+
+    // Construct a time behind the vouched time
+    let time = VouchedTime::new(
+        datetime!(2024-04-13 16:59:59.100),
+        1713027659000,
+        vouch_params.vouch(1713027659000),
+    )
+    .expect("should build");
+    time.check_or_die();
+    assert_eq!(time.get_local_time(), datetime!(2024-04-13 16:59:59.100));
+
+    // Another millisecond and it fails.
+    assert!(VouchedTime::new(
+        datetime!(2024-04-13 16:59:59.099),
+        1713027659000,
+        vouch_params.vouch(1713027659000),
+    )
+    .is_err());
+}
+
+#[test]
+#[should_panic(expected = "failed to construct VouchedTime")]
+fn test_panic_new_miri() {
+    let vouch_params = raffle::VouchingParameters::parse_or_die(
+        "VOUCH-773ec2a0e62c20cd-f9e079b78e895091-fc1da7b1b77c57cb-594b9cce3091464a",
+    );
+
+    VouchedTime::new_or_die(
+        datetime!(2024-04-12 17:01:01.990),
+        1713027659000,
+        vouch_params.vouch(1713027659000),
+    );
+}
+
+#[cfg(not(miri))]
+#[test]
+#[should_panic(expected = "failed to construct VouchedTime")]
+fn test_panic_now() {
+    let vouch_params = raffle::VouchingParameters::parse_or_die(
+        "VOUCH-773ec2a0e62c20cd-f9e079b78e895091-fc1da7b1b77c57cb-594b9cce3091464a",
+    );
+
+    let now = |_| {
+        let now = (datetime!(2023-04-14 17:01:01.990)
+            .assume_utc()
+            .unix_timestamp_nanos()
+            / 1_000_000) as u64;
+        Ok((now, vouch_params.vouch(now)))
+    };
+
+    VouchedTime::now_or_die(now);
+}
+
+#[test]
+#[should_panic(expected = "failed to construct VouchedTime")]
+fn test_panic_now_bad_time() {
+    let now = |_| Err(std::io::Error::other("time callback failed"));
+
+    VouchedTime::now_or_die(now);
+}
+
+// Reject bad vouchers.
+#[test]
+fn test_invalid_miri() {
+    let vouch_params = raffle::VouchingParameters::parse_or_die(
+        "VOUCH-773ec2a0e62c20cd-f9e079b78e895091-fc1da7b1b77c57cb-594b9cce3091464a",
+    );
+
+    // $ date -u -d@1713027659
+    // Sat Apr 13 05:00:59 PM UTC 2024
+    assert!(VouchedTime::new(
+        datetime!(2024-04-13 17:00:59),
+        1713027659000,
+        vouch_params.vouch(1713027659000)
+    )
+    .is_ok());
+
+    // Bad time
+    assert!(format!(
+        "{:?}",
+        VouchedTime::new(
+            datetime!(2024-04-13 17:00:59),
+            1713027659001,
+            vouch_params.vouch(1713027659000)
+        )
+        .unwrap_err()
+    )
+    .contains("base_time does not match voucher"));
+
+    // Bad voucher
+    assert!(format!(
+        "{:?}",
+        VouchedTime::new(
+            datetime!(2024-04-13 17:00:59),
+            1713027659000,
+            vouch_params.vouch(1713027659001)
+        )
+        .unwrap_err()
+    )
+    .contains("base_time does not match voucher"));
+
+    // randomly generated parameters
+    let bad_params = raffle::VouchingParameters::parse_or_die(
+        "VOUCH-d165ec246b320939-2067990c3fc0f62d-309ee23efd609c4b-45b19da4a316ca0e",
+    );
+
+    // Bad params
+    assert!(format!(
+        "{:?}",
+        VouchedTime::new(
+            datetime!(2024-04-13 17:00:59),
+            1713027659000,
+            bad_params.vouch(1713027659000)
+        )
+        .unwrap_err()
+    )
+    .contains("base_time does not match voucher"));
+}
+
+// Make sure we correctly handle (or at least reject) values beyond or
+// at the edge of the representable range.
+#[test]
+fn test_boundaries_miri() {
+    assert!(VouchedTime::check_vouched_time(
+        time::PrimitiveDateTime::MAX
+            .assume_utc()
+            .unix_timestamp_nanos()
+            / 1_000_000,
+        u64::MAX
+    )
+    .is_err());
+    assert!(VouchedTime::check_vouched_time(
+        time::PrimitiveDateTime::MAX
+            .assume_utc()
+            .unix_timestamp_nanos()
+            / 1_000_000,
+        u64::MIN
+    )
+    .is_err());
+    assert!(VouchedTime::check_vouched_time(
+        time::PrimitiveDateTime::MIN
+            .assume_utc()
+            .unix_timestamp_nanos()
+            / 1_000_000,
+        u64::MIN
+    )
+    .is_err());
+    assert!(VouchedTime::check_vouched_time(
+        time::PrimitiveDateTime::MIN
+            .assume_utc()
+            .unix_timestamp_nanos()
+            / 1_000_000,
+        u64::MAX
+    )
+    .is_err());
+
+    VouchedTime::check_vouched_time(0, 0).expect("should pass");
+    VouchedTime::check_vouched_time(0, MAX_BACKWARD_DISCREPANCY_MS).expect("should pass");
+    assert!(VouchedTime::check_vouched_time(0, MAX_BACKWARD_DISCREPANCY_MS + 1).is_err());
+    VouchedTime::check_vouched_time(MAX_FORWARD_DISCREPANCY_MS as i128, 0).expect("should pass");
+    assert!(VouchedTime::check_vouched_time(1 + MAX_FORWARD_DISCREPANCY_MS as i128, 0).is_err());
+
+    // Negative timestamp -> reject.
+    assert!(VouchedTime::check_vouched_time(-1, 0).is_err());
+    assert!(VouchedTime::check_vouched_time(-1, u64::MAX).is_err());
+
+    // Huge timestamps
+    VouchedTime::check_vouched_time(u64::MAX as i128, u64::MAX).expect("should pass");
+    assert!(VouchedTime::check_vouched_time(u64::MAX as i128 + 1, u64::MAX).is_err());
+    VouchedTime::check_vouched_time((u64::MAX - MAX_BACKWARD_DISCREPANCY_MS) as i128, u64::MAX)
+        .expect("should pass");
+    assert!(VouchedTime::check_vouched_time(
+        (u64::MAX - MAX_BACKWARD_DISCREPANCY_MS) as i128 - 1,
+        u64::MAX
+    )
+    .is_err());
+
+    VouchedTime::check_vouched_time(u64::MAX as i128, u64::MAX - MAX_FORWARD_DISCREPANCY_MS)
+        .expect("should pass");
+    assert!(VouchedTime::check_vouched_time(
+        u64::MAX as i128,
+        u64::MAX - MAX_FORWARD_DISCREPANCY_MS - 1
+    )
+    .is_err());
+}

--- a/vouched_time/src/nfs_voucher.rs
+++ b/vouched_time/src/nfs_voucher.rs
@@ -1,0 +1,306 @@
+//! The NFS vouched time backend uses a trusted filesystem's *ctime* to update
+//! the time base.
+//!
+//! Most of the time, the time base can be updated off already opened files.
+//! When the current time base seems far behind, this module can also trigger
+//! an artificial mtime update.
+//!
+//! To use this module as a source of trusted base times for
+//! [`crate::VouchedTime`], you must first add the path to the trusted paths
+//! list.  This is done by calling [`add_trusted_path`] with the path for a
+//! file on a filesystem with trusted ctime updates (e.g., a NFS server
+//! similarly trusted by all peers). The `nfs_voucher` module will now trust
+//! `ctime` for all files on the same device as that path.
+//!
+//! The current process must also have write access to the file at the trusted
+//! path; that's used only to `touch` the file's atime, which forces a ctime
+//! update).
+//!
+//! You can then pass [`get_base_time`] to [`crate::VouchedTime::now_or_die`]
+//! to generate a fresh vouched time for the current time.  The
+//! [`get_base_time`] function will perform I/O and block on some internal
+//! locks to update the base time if it looks like the current base time would
+//! result in a failure. Use [`get_base_time_unlocked`] to skip the I/O and
+//! blocking, and always return the current base time, however stale it might
+//! look.  This should only be used in niche situations where we've already
+//! ensured the base time is up to date and blocking is forbidden.
+//!
+//! You may update the base time (and thue ensure [`get_base_time`] doesn't
+//! block) by calling [`observe_file_time`] with a recently changed file on a
+//! trusted device.  In general, it's always safe to call
+//! [`observe_file_time`] with any file: the function disregards files on
+//! untrusted devices, and base time updates are only applied when they
+//! advance the base time.
+use std::collections::BTreeMap;
+use std::io::Result;
+use std::path::PathBuf;
+use std::sync::RwLock;
+
+use crate::AtomicBaseTime;
+
+// Trusted paths map from device id to path that is safe to touch.
+static TRUSTED_PATHS: RwLock<BTreeMap<u64, PathBuf>> = RwLock::new(BTreeMap::new());
+
+static BASE_TIME: AtomicBaseTime = AtomicBaseTime::new();
+
+/// Adds `path` to the set of trusted paths for the NFS vouching module.
+///
+/// Any file stored on the same device as `path` is assumed to have a
+/// trustworthy ctime.
+///
+/// The current process must have write access to that path, to force ctime updates.
+#[inline(never)]
+pub fn add_trusted_path(path: PathBuf) -> Result<()> {
+    use std::os::unix::fs::MetadataExt;
+
+    let file = std::fs::File::options()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&path)?;
+    let stat = file.metadata()?;
+    let dev = stat.dev();
+    // Check that we can actually use this path for base time updates.
+    //
+    // This call may fail for I/O, but should not fail
+    // because the device isn't trusted (i.e., no `Ok(None)`).
+    let _ = update_base_time(
+        &file,
+        UpdateOptions {
+            blocking: false,
+            touch: true,
+            extra_device: Some(dev),
+        },
+    )?
+    .1
+    .expect("Path is trusted.");
+
+    TRUSTED_PATHS.write().unwrap().insert(dev, path);
+    Ok(())
+}
+
+const DEFAULT_LEEWAY_MS: u64 = 2 * crate::MAX_FORWARD_DISCREPANCY_MS / 3;
+thread_local! {
+    /// The last time we updated the base time, or decided we didn't need to.
+    static LAST_UPDATE: std::cell::Cell<Option<std::time::Instant>> = Default::default();
+}
+
+/// Returns whether it's worth refreshing the current base time, because it's
+/// (approximately) older than `leeway_ms`.
+///
+/// If `leeway_ms` is None, use an appropriate default.
+pub fn should_refresh_base_time(leeway_ms: Option<u64>, now: Option<time::OffsetDateTime>) -> bool {
+    if now.is_none() {
+        if let Some(last_update) = LAST_UPDATE.get() {
+            // We don't need that kind of precision, just bail early.
+            if last_update.elapsed() < std::time::Duration::from_millis(100) {
+                // TODO: should jitter
+                return false;
+            }
+        }
+    }
+
+    // Either we'll update the base time, or we'll decide it's good enough; in
+    // either case, we shouldn't need to update again for a while.
+    LAST_UPDATE.set(Some(std::time::Instant::now()));
+
+    let leeway_ms = leeway_ms.unwrap_or(DEFAULT_LEEWAY_MS);
+    let now = now.unwrap_or_else(time::OffsetDateTime::now_utc);
+    let wanted: u64 = (now.unix_timestamp_nanos() / 1_000_000).clamp(0, u64::MAX as i128) as u64;
+    let (base_ms, _voucher) = get_base_time_unlocked(now).expect("_unlocked does not fail");
+
+    // Refresh if the base time looks stale and we have some trusted paths to
+    // refresh with.
+    //
+    // TODO: should jitter a little around here.
+    wanted.saturating_sub(base_ms) > leeway_ms && !TRUSTED_PATHS.read().unwrap().is_empty()
+}
+
+/// Given an arbitrary file, attempts to advance the base time based on the
+/// file's ctime.
+///
+/// Returns the base time and voucher derived from the file if it is on a
+/// trusted device (see [`add_trusted_path`]) and the `stat` call succeeded.
+/// That base time may differ from the one stored in memory under contention
+/// or if the file's ctime is older than the current base time.
+///
+/// Returns `Ok(None)` if the file is not on a trusted device, and propagates
+/// any I/O error from `stat` otherwise.
+///
+/// This function `stat`s the file, but is otherwise wait-free.
+#[inline(always)]
+pub fn observe_file_time(
+    file: &std::fs::File,
+) -> Result<(std::fs::Metadata, Option<(u64, raffle::Voucher)>)> {
+    update_base_time(
+        file,
+        UpdateOptions {
+            blocking: false,
+            touch: false,
+            extra_device: None,
+        },
+    )
+}
+
+/// Attempts to advance the base time based on `file`'s ctime, if it makes
+/// sense to refresh the base time (no-ops otherwise).
+pub fn maybe_observe_file_time(file: &std::fs::File) {
+    if should_refresh_base_time(None, None) {
+        let _ = observe_file_time(file);
+    }
+}
+
+/// Attempts to update the base time if it is already stale (more than 1000
+/// milliseconds behind).
+#[inline(never)]
+pub fn scan_base_time() -> Result<()> {
+    // We want to be more aggressive than the default leeway, when explicitly
+    // requesting a base time update.
+    const _: () = assert!(1000 < DEFAULT_LEEWAY_MS);
+    if should_refresh_base_time(Some(1000), None) {
+        scan_for_base_time_impl()?;
+    }
+
+    Ok(())
+}
+
+/// Returns the current base time and voucher.
+///
+/// Does not attempt to move the base time forward if it looks stale,
+/// but also never fails.
+///
+/// This function is lock-free.
+#[inline(always)]
+pub fn get_base_time_unlocked(_now: time::OffsetDateTime) -> Result<(u64, raffle::Voucher)> {
+    Ok(BASE_TIME.snapshot())
+}
+
+/// Attempts to return an up-to-date base time and voucher.
+///
+/// Returns the current base time if it looks more than recent enough to match
+/// the current time. Otherwise, attempts to update the base time by touching
+/// some of the trusted paths and returns the first successful update.
+///
+/// This function fails when all update attempts fail, and when no trusted
+/// path is defined.
+///
+/// This function is lock-free when the base time is up to date; if the base
+/// time must be updated, that can be slow, and requires I/O and locking.
+pub fn get_base_time(now: time::OffsetDateTime) -> Result<(u64, raffle::Voucher)> {
+    if should_refresh_base_time(None, Some(now)) {
+        scan_for_base_time_impl()
+    } else {
+        get_base_time_unlocked(now)
+    }
+}
+
+#[inline(never)]
+fn scan_for_base_time_impl() -> Result<(u64, raffle::Voucher)> {
+    let mut err: Option<std::io::Error> = None;
+    let trusted_paths = TRUSTED_PATHS.read().unwrap();
+    for path in trusted_paths.values() {
+        let file = std::fs::File::options()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)?;
+        match update_base_time(
+            &file,
+            UpdateOptions {
+                blocking: true,
+                touch: true,
+                extra_device: None,
+            },
+        ) {
+            Ok((_, Some(update))) => return Ok(update),
+            Ok(_) => {}
+            Err(e) => {
+                err.get_or_insert(e);
+            }
+        }
+    }
+
+    Err(err.unwrap_or_else(|| {
+        std::io::Error::other(
+            "no nfs_voucher trusted path (or all paths moved to a different device)",
+        )
+    }))
+}
+
+struct UpdateOptions {
+    blocking: bool,
+    touch: bool,
+    extra_device: Option<u64>,
+}
+
+#[inline(never)]
+fn update_base_time(
+    file: &std::fs::File,
+    options: UpdateOptions,
+) -> Result<(std::fs::Metadata, Option<(u64, raffle::Voucher)>)> {
+    use std::os::unix::fs::MetadataExt;
+
+    if options.touch {
+        file.set_times(std::fs::FileTimes::new().set_accessed(std::time::SystemTime::now()))?;
+    }
+
+    let begin = std::time::Instant::now();
+
+    let stat = file.metadata()?;
+    let dev = stat.dev();
+    if !TRUSTED_PATHS.read().unwrap().contains_key(&dev) && options.extra_device != Some(dev) {
+        return Ok((stat, None));
+    }
+    const VOUCH_PARAMS: raffle::VouchingParameters = raffle::VouchingParameters::parse_or_die(
+        "VOUCH-773ec2a0e62c20cd-f9e079b78e895091-fc1da7b1b77c57cb-594b9cce3091464a",
+    );
+
+    let millis_since_epoch = (stat.ctime() as u64)
+        .saturating_mul(1000)
+        .saturating_add((stat.ctime_nsec() as u64) / 1_000_000);
+    let update = (millis_since_epoch, VOUCH_PARAMS.vouch(millis_since_epoch));
+
+    let updated = if options.blocking {
+        BASE_TIME.update(update);
+        true
+    } else {
+        BASE_TIME.try_update(update)
+    };
+
+    if updated {
+        LAST_UPDATE.set(Some(begin));
+    }
+
+    Ok((stat, Some(update)))
+}
+
+#[cfg(not(miri))]
+#[test]
+fn smoke_test() {
+    use test_dir::{DirBuilder, TestDir};
+
+    let temp = TestDir::temp();
+    add_trusted_path(temp.path("test.file")).expect("should succeed");
+    let _ = crate::VouchedTime::now_or_die(get_base_time_unlocked);
+
+    // The base time is now invalid.
+    std::thread::sleep(std::time::Duration::from_secs(4));
+
+    // Confirm it's invalid.
+    assert!(crate::VouchedTime::now(get_base_time_unlocked).is_err());
+    // But we can pull the base time forward.
+    let _ = crate::VouchedTime::now_or_die(get_base_time);
+    let _ = crate::VouchedTime::now_or_die(get_base_time_unlocked);
+
+    // Invalidate the base time again.
+    std::thread::sleep(std::time::Duration::from_secs(4));
+    assert!(crate::VouchedTime::now(get_base_time_unlocked).is_err());
+
+    std::fs::write(temp.path("some_random_file"), b"123").unwrap();
+    let file = std::fs::File::open(temp.path("some_random_file")).unwrap();
+    // Update base time
+    let _ = observe_file_time(&file).unwrap();
+    let _ = crate::VouchedTime::now_or_die(get_base_time_unlocked);
+}


### PR DESCRIPTION
In distributed systems like the woodpile, it's important for some timestamps to be in the same vicinity as the "real" real time.

Unlike Spanner, the error bar on the timestamps doesn't have to be tight to the microsecond.  However, we assume that all peers can agreee on the current time up to ~2 seconds (the error budget is split evenly between leap second handling and clock sync error).

The vouched time crate uses a slowly updated "trusted" time and vouches that a fresh timestamp isn't too far from the most recent trusted time.  Roughtime servers were designed as trusted time sources, but the ecosystem doesn't look great (very few implementations, the latest version of the RFC is very different from the most common implementation, prototype-quality Rust client)... so we just use ctime from trusted mount points (e.g., NFS servers): on NFS, the ctime is always set by the server, so, while that time source might be badly synchronised with reality, everyone should be able to agree on the same time.

Start reading at atomic_base_time, then `lib.rs`.  The `nfs_voucher` module is mostly uninteresting filesystem manipulation, and "just" implements the logic needed by the `VouchedTime` class on top of `atomic_base_time`.