### PR TITLE
Add vouched_time crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "hcobs",
   "owning_iovec",
   "sliding_deque",
+  "vouched_time",
 ]
 
 resolver = "2"

--- a/vouched_time/Cargo.toml
+++ b/vouched_time/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "vouched_time"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+raffle = "0.0.1"
+# https://users.rust-lang.org/t/the-state-of-time-in-rust-leaps-and-bounds/107620
+# we only need UTC, and don't really care what happens with leap seconds.
+time = "0.3"
+
+[dev-dependencies]
+mutants = "0.0.3"
+test_dir = "0.2"
+time = { version = "0.3", features = ["macros"]}
+
+[lints]
+workspace = true

--- a/vouched_time/src/atomic_base_time.rs
+++ b/vouched_time/src/atomic_base_time.rs
@@ -1,0 +1,239 @@
+//! Implement a lock-free pair of base_time_ms and corresponding voucher
+//! with two copies and a sequence number.
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Mutex;
+
+#[derive(Debug)]
+struct BaseTime {
+    base_time_ms: AtomicU64,
+    voucher: AtomicU64,
+}
+
+#[derive(Debug)]
+struct WriteToken {}
+
+/// An [`AtomicBaseTime`] is a lock-free pair of `base_time_ms` and
+/// corresponding voucher.
+///
+/// Internally, it's implemented as a sequence number and two copies.
+/// At any one time, the copy at `sequence % len` is stable (not being
+/// written).  A read is valid if the sequence didn't change mid-snapshot.
+#[derive(Debug)]
+pub struct AtomicBaseTime {
+    lock: Mutex<WriteToken>,
+    // The snapshot at sequence % len is stable; the next one may be mid-update.
+    sequence: AtomicU64,
+    snapshots: [BaseTime; 2],
+}
+
+impl Default for AtomicBaseTime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+const _: () = assert!(std::mem::size_of::<raffle::Voucher>() == std::mem::size_of::<u64>());
+
+union TransmuteVoucher {
+    bits: u64,
+    voucher: raffle::Voucher,
+}
+
+impl BaseTime {
+    /// Returns a new `BaseTime` initialised for the epoch.
+    const fn new() -> Self {
+        const VOUCH_PARAMS: raffle::VouchingParameters = raffle::VouchingParameters::parse_or_die(
+            "VOUCH-773ec2a0e62c20cd-f9e079b78e895091-fc1da7b1b77c57cb-594b9cce3091464a",
+        );
+
+        let base_time_ms = 0u64;
+        let voucher = VOUCH_PARAMS.vouch(base_time_ms);
+        let voucher = unsafe { TransmuteVoucher { voucher }.bits };
+        Self {
+            base_time_ms: AtomicU64::new(base_time_ms),
+            voucher: AtomicU64::new(voucher),
+        }
+    }
+
+    /// Updates the internal value with release stores.
+    ///
+    /// The voucher must match base_time_ms.
+    pub fn update(&self, base_time_ms: u64, voucher: raffle::Voucher) {
+        assert!(crate::BASE_TIME_CHECK.check(base_time_ms, voucher));
+
+        self.base_time_ms.store(base_time_ms, Ordering::Release);
+        self.voucher.store(
+            unsafe { TransmuteVoucher { voucher }.bits },
+            Ordering::Release,
+        );
+    }
+
+    /// Returns a snapshot of the current pair.
+    ///
+    /// The snapshot may be invalid when executed concurrently with an update.
+    pub fn snapshot(&self) -> (u64, u64) {
+        let bits = self.voucher.load(Ordering::Acquire);
+        let base_time_ms = self.base_time_ms.load(Ordering::Acquire);
+
+        // Can't check here because we might have a racy update.
+        (base_time_ms, bits)
+    }
+}
+
+impl AtomicBaseTime {
+    /// Returns a new `AtomicBaseTime` instance initialised at the epoch.
+    pub const fn new() -> Self {
+        Self {
+            lock: Mutex::new(WriteToken {}),
+            sequence: AtomicU64::new(0),
+            snapshots: [BaseTime::new(), BaseTime::new()],
+        }
+    }
+
+    /// Returns the current sequence number.
+    pub fn sequence(&self) -> u64 {
+        self.sequence.load(Ordering::Relaxed)
+    }
+
+    /// Lock-freely takes a consistent snapshot of the `AtomicBaseTime`.
+    ///
+    /// The return value corresponds to the most recent `update`d pair
+    /// on entry, or one of the values `update`d between entry and exit.
+    pub fn snapshot(&self) -> (u64, raffle::Voucher) {
+        let mut sequence = self.sequence.load(Ordering::Acquire);
+
+        loop {
+            let (base_time_ms, bits) =
+                self.snapshots[(sequence as usize) % self.snapshots.len()].snapshot();
+            let next_sequence = self.sequence.load(Ordering::Acquire);
+            if sequence == next_sequence {
+                // We got a good read, transmute!
+                //
+                // It would be safe to transmute earlier, since each 64-bit
+                // load is atomic, but this is the general pattern.
+                let voucher = unsafe { TransmuteVoucher { bits }.voucher };
+                assert!(crate::BASE_TIME_CHECK.check(base_time_ms, voucher));
+
+                return (base_time_ms, voucher);
+            }
+
+            sequence = next_sequence;
+        }
+    }
+
+    /// Updates the value stored in the `AtomicBaseTime`.
+    ///
+    /// Calls serialise on an internal lock, but do not block
+    /// `snapshot` calls.
+    pub fn update(&self, update: (u64, raffle::Voucher)) {
+        let mut token = loop {
+            match self.lock.lock() {
+                Ok(guard) => break guard,
+                // The lock only serves for mutual exclusion, if it's
+                // poisoned, the previous holder isn't updating.
+                Err(_) => self.lock.clear_poison(),
+            }
+        };
+
+        self.advance_once(&mut token, update);
+    }
+
+    /// Wait-free attempt at updating the value stored in the `AtomicBaseTime`.
+    ///
+    /// Returns whether the instance was updated.
+    ///
+    /// Calls still serialise on an internal lock, but they return `false`
+    /// instead of blocking.
+    pub fn try_update(&self, update: (u64, raffle::Voucher)) -> bool {
+        use std::sync::TryLockError::*;
+
+        let mut token = match self.lock.try_lock() {
+            Ok(guard) => guard,
+            Err(Poisoned(_)) => {
+                self.lock.clear_poison();
+                return false;
+            }
+            Err(WouldBlock) => return false,
+        };
+
+        self.advance_once(&mut token, update)
+    }
+
+    fn advance_once(&self, _token: &mut WriteToken, update: (u64, raffle::Voucher)) -> bool {
+        let current = self.sequence.load(Ordering::Relaxed);
+        let current_base_time_ms = self.snapshots[(current as usize) % self.snapshots.len()]
+            .snapshot()
+            .0;
+        if update.0 < current_base_time_ms {
+            // The update is older than the current value; skip it.
+            return false;
+        }
+
+        let next = current.wrapping_add(1);
+        let idx = (next as usize) % self.snapshots.len();
+
+        self.snapshots[idx].update(update.0, update.1);
+        self.sequence.store(next, Ordering::Release); // Commit the write
+        true
+    }
+}
+
+// Make sure this works.
+#[cfg(test)]
+static _BASE_TIME: AtomicBaseTime = AtomicBaseTime::new();
+
+#[test]
+fn test_smoke_miri() {
+    const VOUCH_PARAMS: raffle::VouchingParameters = raffle::VouchingParameters::parse_or_die(
+        "VOUCH-773ec2a0e62c20cd-f9e079b78e895091-fc1da7b1b77c57cb-594b9cce3091464a",
+    );
+
+    let base_time: AtomicBaseTime = Default::default();
+    assert_eq!(base_time.sequence(), 0);
+
+    assert_eq!(base_time.snapshot().0, 0);
+
+    {
+        let (time, voucher) = base_time.snapshot();
+        assert!(VOUCH_PARAMS.checking_parameters().check(time, voucher));
+    }
+
+    base_time.update((42, VOUCH_PARAMS.vouch(42)));
+    assert_eq!(base_time.sequence(), 1);
+
+    assert_eq!(base_time.snapshot().0, 42);
+    {
+        let (time, voucher) = base_time.snapshot();
+        assert!(VOUCH_PARAMS.checking_parameters().check(time, voucher));
+    }
+
+    base_time.try_update((100, VOUCH_PARAMS.vouch(100)));
+    assert_eq!(base_time.sequence(), 2);
+
+    assert_eq!(base_time.snapshot().0, 100);
+    {
+        let (time, voucher) = base_time.snapshot();
+        assert!(VOUCH_PARAMS.checking_parameters().check(time, voucher));
+    }
+
+    // Reject non-monotonic updates.
+    base_time.try_update((99, VOUCH_PARAMS.vouch(99)));
+    assert_eq!(base_time.snapshot().0, 100);
+    {
+        let (time, voucher) = base_time.snapshot();
+        assert!(VOUCH_PARAMS.checking_parameters().check(time, voucher));
+    }
+}
+
+#[test]
+#[should_panic(expected = "BASE_TIME_CHECK.check")]
+fn test_panic_miri() {
+    const VOUCH_PARAMS: raffle::VouchingParameters = raffle::VouchingParameters::parse_or_die(
+        "VOUCH-773ec2a0e62c20cd-f9e079b78e895091-fc1da7b1b77c57cb-594b9cce3091464a",
+    );
+
+    let base_time = AtomicBaseTime::new();
+
+    base_time.update((42, VOUCH_PARAMS.vouch(43)));
+}

--- a/vouched_time/src/lib.rs
+++ b/vouched_time/src/lib.rs
@@ -1,0 +1,520 @@
+//! The `vouched_time` crate exposes the [`VouchedTime`] type, a wrapper
+//! around a trusted base time, a [`raffle::Voucher`] as a weak witness that
+//! the base time deserves our trust, and a presumably more up-to-date
+//! [`time::PrimitiveDateTime`] local time.
+//!
+//! It is meant to help time-based logic systems detect innocent bugs in time
+//! handling, especially in protocols where when generating times far in the
+//! future can result in hard to debug issues.
+//!
+//! The source of trusted base times could be a [Roughtime
+//! server](https://datatracker.ietf.org/doc/draft-ietf-ntp-roughtime/), or a
+//! local [ClockBound](https://github.com/aws/clock-bound) daemon (neither
+//! option is implemented yet).
+//!
+//! For now the only trusted base time source is a trusted filesystem's ctimes
+//!([`nfs_voucher`]): we want to use vouched times in a library that exchanges
+//! messages over NFS, so it makes sense to assume everyone can access the NFS
+//! server.
+mod atomic_base_time;
+pub mod nfs_voucher;
+
+use std::io::Result;
+
+#[cfg(test)]
+use time::macros::datetime;
+
+pub use atomic_base_time::AtomicBaseTime;
+
+/// We allow times that are at most slightly less than 3 seconds (3000
+/// ms) ahead of the vouched time.  This tolerance is relatively tight
+/// because it's important to avoid time travel from the future.
+///
+/// The value is slightly less than 3000 ms to account for rounding,
+/// truncation, and off-by-ones.
+pub const MAX_FORWARD_DISCREPANCY_MS: u64 = 2990;
+
+/// We allow times that are most slightly less than 60 seconds (60 000 ms)
+/// behind the vouched time.  This tolerance is loose because asynchronous
+/// systems fundamentally have to deal with slow peers, and because a program
+/// could always keep using a stale base time.
+///
+/// The value is slightly less than 60 000 ms to account for rounding,
+/// truncation, and off-by-ones.
+pub const MAX_BACKWARD_DISCREPANCY_MS: u64 = 59_900;
+
+// Generated with `generate_raffle_parameters "woodpile vouched time"`
+const BASE_TIME_CHECK: raffle::CheckingParameters =
+    raffle::CheckingParameters::parse_or_die("CHECK-fc1da7b1b77c57cb-594b9cce3091464a");
+
+/// A [`VouchedTime`] is the combination of a local [`time::PrimitiveDateTime`]
+/// in UTC, and a [`raffle::Voucher`] for a [`u64`] base time (milliseconds since
+/// Unix epoch) such that the local time is at most
+/// [`MAX_BACKWARD_DISCREPANCY_MS`] behind the base time or
+/// [`MAX_FORWARD_DISCREPANCY_MS`] ahead of the base time.  Once a
+/// [`VouchedTime`] is constructed with a trusted base time, we assume it's not
+/// (deliberately) too far in the future, and likely not too far in the past
+/// either.
+///
+/// In this crate, the term "local time" refers to each machine's
+/// approximation of UTC.
+#[derive(Clone, Copy, Debug)]
+pub struct VouchedTime {
+    local_time: time::PrimitiveDateTime,
+    base_time_ms: u64,
+    voucher: raffle::Voucher,
+}
+
+impl VouchedTime {
+    /// Constructs a new VouchedTime, or returns a reason why it's invalid.
+    ///
+    /// This only errors out when something's really wrong; consider using
+    /// [`VouchedTime::new_or_die`].
+    pub fn new(
+        local_time: time::PrimitiveDateTime,
+        base_time_ms: u64,
+        voucher: raffle::Voucher,
+    ) -> Result<VouchedTime> {
+        Self::check(local_time, base_time_ms, voucher)?;
+        let ret = VouchedTime {
+            local_time,
+            base_time_ms,
+            voucher,
+        };
+
+        ret.check_or_die();
+        Ok(ret)
+    }
+
+    /// Construct a new `VouchedTime` or dies trying.
+    pub fn new_or_die(
+        local_time: time::PrimitiveDateTime,
+        base_time_ms: u64,
+        voucher: raffle::Voucher,
+    ) -> VouchedTime {
+        VouchedTime::new(local_time, base_time_ms, voucher)
+            .expect("failed to construct VouchedTime")
+    }
+
+    /// Constructs a new VouchedTime based on the time returned by `base_time_provider`,
+    /// or returns a reason why the operation failed.
+    ///
+    /// This only errors out when something's really wrong (or the `base_time_provider`
+    /// errors out); consider using [`VouchedTime::now_or_die`].
+    pub fn now(
+        base_time_provider: impl FnOnce(time::OffsetDateTime) -> Result<(u64, raffle::Voucher)>,
+    ) -> Result<VouchedTime> {
+        let now = time::OffsetDateTime::now_utc();
+        let (base_time_ms, voucher) = base_time_provider(now)?;
+        VouchedTime::new(
+            time::PrimitiveDateTime::new(now.date(), now.time()),
+            base_time_ms,
+            voucher,
+        )
+    }
+
+    /// Returns a `VouchedTime` for the result of `base_time_provider` or dies trying.
+    pub fn now_or_die(
+        base_time_provider: impl FnOnce(time::OffsetDateTime) -> Result<(u64, raffle::Voucher)>,
+    ) -> VouchedTime {
+        VouchedTime::now(base_time_provider).expect("failed to construct VouchedTime")
+    }
+
+    /// Returns the local time stored in the `VouchedTime`.
+    pub fn get_local_time(self) -> time::PrimitiveDateTime {
+        self.check_or_die(); // Internal self-check before returning `local_time`.
+        self.local_time
+    }
+
+    /// Checks the internal representation for validity.  Panics
+    /// if anything's wrong: the constructors enforce the same conditions.
+    pub fn check_or_die(self) {
+        Self::check(self.local_time, self.base_time_ms, self.voucher)
+            .expect("Constructed VouchedTime should be valid");
+    }
+
+    /// Checks whether this `local_time` would be valid for `base_time_ms`
+    /// and the corresponding vouched.
+    pub fn check(
+        local_time: time::PrimitiveDateTime,
+        base_time_ms: u64,
+        voucher: raffle::Voucher,
+    ) -> Result<()> {
+        if !BASE_TIME_CHECK.check(base_time_ms, voucher) {
+            return Err(std::io::Error::other("base_time does not match voucher"));
+        }
+
+        Self::check_vouched_time(
+            local_time.assume_utc().unix_timestamp_nanos() / 1_000_000,
+            base_time_ms,
+        )
+    }
+
+    fn check_vouched_time(local_time_ms: i128, base_time_ms: u64) -> Result<()> {
+        let other = std::io::Error::other;
+
+        if local_time_ms < 0 {
+            return Err(other("local_time is before the Unix epoch"));
+        }
+
+        if local_time_ms > u64::MAX as i128 {
+            return Err(other("local time is out of range"));
+        }
+
+        let local_time_ms = local_time_ms as u64;
+        // if local_time - base_time in [-MAX_BACKWARD_DISCREPANCY_MS, MAX_FORWARD_DISCREPANCY_MS]
+        //
+        // We subtract base_time_ns, and add MAX_BACKWARD_DISCREPANCY_MS.  This maps the
+        // allowed range to `[0, MAX_BACKWARD_DISCREPANCY_MS + MAX_FORWARD_DISCREPANCY_MS]`.
+        if local_time_ms
+            .wrapping_sub(base_time_ms)
+            .wrapping_add(MAX_BACKWARD_DISCREPANCY_MS)
+            <= MAX_BACKWARD_DISCREPANCY_MS + MAX_FORWARD_DISCREPANCY_MS
+        {
+            return Ok(());
+        }
+
+        if local_time_ms > base_time_ms {
+            return Err(other("local_time is too far ahead of base_time"));
+        }
+
+        Err(other("local_time is too far behind base_time"))
+    }
+}
+
+// Check that we can construct `VouchedTime`s with an exact match on the base time.
+#[test]
+fn test_happy_path_miri() {
+    let vouch_params = raffle::VouchingParameters::parse_or_die(
+        "VOUCH-773ec2a0e62c20cd-f9e079b78e895091-fc1da7b1b77c57cb-594b9cce3091464a",
+    );
+
+    // $ date -u -d@1713027659
+    // Sat Apr 13 05:00:59 PM UTC 2024
+
+    assert_eq!(
+        VouchedTime::new_or_die(
+            datetime!(2024-04-13 17:00:59),
+            1713027659000,
+            vouch_params.vouch(1713027659000)
+        )
+        .get_local_time(),
+        datetime!(2024-04-13 17:00:59),
+    );
+
+    if !cfg!(miri) {
+        let now = |now: time::OffsetDateTime| {
+            let now = (now.unix_timestamp_nanos() / 1_000_000) as u64;
+            Ok((now, vouch_params.vouch(now)))
+        };
+
+        println!("{:?}", VouchedTime::now_or_die(now));
+        println!("{:?}", VouchedTime::now(now).expect("must succeed"));
+    }
+}
+
+// Go right at the end of the allowed discrepancy between the base time and the local time.
+#[test]
+fn test_limit_miri() {
+    let vouch_params = raffle::VouchingParameters::parse_or_die(
+        "VOUCH-773ec2a0e62c20cd-f9e079b78e895091-fc1da7b1b77c57cb-594b9cce3091464a",
+    );
+
+    // $ date -u -d@1713027659
+    // Sat Apr 13 05:00:59 PM UTC 2024
+
+    // Construct a time ahead of the vouched time
+    let time = VouchedTime::new(
+        datetime!(2024-04-13 17:01:01.990),
+        1713027659000,
+        vouch_params.vouch(1713027659000),
+    )
+    .expect("should build");
+    time.check_or_die();
+    assert_eq!(time.get_local_time(), datetime!(2024-04-13 17:01:01.99));
+
+    // One more millisecond, and it fails.
+    assert!(VouchedTime::new(
+        datetime!(2024-04-13 17:01:01.991),
+        1713027659000,
+        vouch_params.vouch(1713027659000),
+    )
+    .is_err());
+
+    // Construct a time behind the vouched time
+    let time = VouchedTime::new(
+        datetime!(2024-04-13 16:59:59.100),
+        1713027659000,
+        vouch_params.vouch(1713027659000),
+    )
+    .expect("should build");
+    time.check_or_die();
+    assert_eq!(time.get_local_time(), datetime!(2024-04-13 16:59:59.100));
+
+    // Another millisecond and it fails.
+    assert!(VouchedTime::new(
+        datetime!(2024-04-13 16:59:59.099),
+        1713027659000,
+        vouch_params.vouch(1713027659000),
+    )
+    .is_err());
+}
+
+// Make sure that we can detect corruption.
+#[test]
+#[should_panic(expected = "local_time is too far behind base_time")]
+fn test_corruption_local_time_miri() {
+    let vouch_params = raffle::VouchingParameters::parse_or_die(
+        "VOUCH-773ec2a0e62c20cd-f9e079b78e895091-fc1da7b1b77c57cb-594b9cce3091464a",
+    );
+
+    // $ date -u -d@1713027659
+    // Sat Apr 13 05:00:59 PM UTC 2024
+
+    // Construct a time ahead of the vouched time
+    let mut time = VouchedTime::new(
+        datetime!(2024-04-13 17:01:01.990),
+        1713027659000,
+        vouch_params.vouch(1713027659000),
+    )
+    .expect("should build");
+    assert_eq!(time.get_local_time(), datetime!(2024-04-13 17:01:01.99));
+
+    time.local_time = datetime!(2024-04-13 16:59:01.990);
+    time.check_or_die();
+}
+
+#[test]
+#[should_panic(expected = "local_time is too far ahead of base_time")]
+fn test_corruption_local_time_again_miri() {
+    let vouch_params = raffle::VouchingParameters::parse_or_die(
+        "VOUCH-773ec2a0e62c20cd-f9e079b78e895091-fc1da7b1b77c57cb-594b9cce3091464a",
+    );
+
+    // $ date -u -d@1713027659
+    // Sat Apr 13 05:00:59 PM UTC 2024
+
+    // Construct a time ahead of the vouched time
+    let mut time = VouchedTime::new(
+        datetime!(2024-04-13 17:01:01.990),
+        1713027659000,
+        vouch_params.vouch(1713027659000),
+    )
+    .expect("should build");
+    assert_eq!(time.get_local_time(), datetime!(2024-04-13 17:01:01.99));
+
+    time.local_time = datetime!(2024-04-13 17:02:01.990);
+    time.check_or_die();
+}
+
+#[test]
+#[should_panic(expected = "base_time does not match voucher")]
+fn test_corruption_bad_base_time_miri() {
+    let vouch_params = raffle::VouchingParameters::parse_or_die(
+        "VOUCH-773ec2a0e62c20cd-f9e079b78e895091-fc1da7b1b77c57cb-594b9cce3091464a",
+    );
+
+    // $ date -u -d@1713027659
+    // Sat Apr 13 05:00:59 PM UTC 2024
+
+    // Construct a time ahead of the vouched time
+    let mut time = VouchedTime::new(
+        datetime!(2024-04-13 17:01:01.990),
+        1713027659000,
+        vouch_params.vouch(1713027659000),
+    )
+    .expect("should build");
+    assert_eq!(time.get_local_time(), datetime!(2024-04-13 17:01:01.99));
+
+    time.base_time_ms = 1713027659001;
+    time.check_or_die();
+}
+
+#[test]
+#[should_panic(expected = "base_time does not match voucher")]
+fn test_corruption_bad_voucher_miri() {
+    let vouch_params = raffle::VouchingParameters::parse_or_die(
+        "VOUCH-773ec2a0e62c20cd-f9e079b78e895091-fc1da7b1b77c57cb-594b9cce3091464a",
+    );
+
+    // $ date -u -d@1713027659
+    // Sat Apr 13 05:00:59 PM UTC 2024
+
+    // Construct a time ahead of the vouched time
+    let mut time = VouchedTime::new(
+        datetime!(2024-04-13 17:01:01.990),
+        1713027659000,
+        vouch_params.vouch(1713027659000),
+    )
+    .expect("should build");
+    assert_eq!(time.get_local_time(), datetime!(2024-04-13 17:01:01.99));
+
+    time.voucher = vouch_params.vouch(1713027659001);
+    time.check_or_die();
+}
+
+#[test]
+#[should_panic(expected = "failed to construct VouchedTime")]
+fn test_panic_new_miri() {
+    let vouch_params = raffle::VouchingParameters::parse_or_die(
+        "VOUCH-773ec2a0e62c20cd-f9e079b78e895091-fc1da7b1b77c57cb-594b9cce3091464a",
+    );
+
+    VouchedTime::new_or_die(
+        datetime!(2024-04-12 17:01:01.990),
+        1713027659000,
+        vouch_params.vouch(1713027659000),
+    );
+}
+
+#[cfg(not(miri))]
+#[test]
+#[should_panic(expected = "failed to construct VouchedTime")]
+fn test_panic_now() {
+    let vouch_params = raffle::VouchingParameters::parse_or_die(
+        "VOUCH-773ec2a0e62c20cd-f9e079b78e895091-fc1da7b1b77c57cb-594b9cce3091464a",
+    );
+
+    let now = |_| {
+        let now = (datetime!(2023-04-14 17:01:01.990)
+            .assume_utc()
+            .unix_timestamp_nanos()
+            / 1_000_000) as u64;
+        Ok((now, vouch_params.vouch(now)))
+    };
+
+    VouchedTime::now_or_die(now);
+}
+
+#[test]
+#[should_panic(expected = "failed to construct VouchedTime")]
+fn test_panic_now_bad_time() {
+    let now = |_| Err(std::io::Error::other("time callback failed"));
+
+    VouchedTime::now_or_die(now);
+}
+
+// Reject bad vouchers.
+#[test]
+fn test_invalid_miri() {
+    let vouch_params = raffle::VouchingParameters::parse_or_die(
+        "VOUCH-773ec2a0e62c20cd-f9e079b78e895091-fc1da7b1b77c57cb-594b9cce3091464a",
+    );
+
+    // $ date -u -d@1713027659
+    // Sat Apr 13 05:00:59 PM UTC 2024
+    assert!(VouchedTime::new(
+        datetime!(2024-04-13 17:00:59),
+        1713027659000,
+        vouch_params.vouch(1713027659000)
+    )
+    .is_ok());
+
+    // Bad time
+    assert!(format!(
+        "{:?}",
+        VouchedTime::new(
+            datetime!(2024-04-13 17:00:59),
+            1713027659001,
+            vouch_params.vouch(1713027659000)
+        )
+        .unwrap_err()
+    )
+    .contains("base_time does not match voucher"));
+
+    // Bad voucher
+    assert!(format!(
+        "{:?}",
+        VouchedTime::new(
+            datetime!(2024-04-13 17:00:59),
+            1713027659000,
+            vouch_params.vouch(1713027659001)
+        )
+        .unwrap_err()
+    )
+    .contains("base_time does not match voucher"));
+
+    // randomly generated parameters
+    let bad_params = raffle::VouchingParameters::parse_or_die(
+        "VOUCH-d165ec246b320939-2067990c3fc0f62d-309ee23efd609c4b-45b19da4a316ca0e",
+    );
+
+    // Bad params
+    assert!(format!(
+        "{:?}",
+        VouchedTime::new(
+            datetime!(2024-04-13 17:00:59),
+            1713027659000,
+            bad_params.vouch(1713027659000)
+        )
+        .unwrap_err()
+    )
+    .contains("base_time does not match voucher"));
+}
+
+// Make sure we correctly handle (or at least reject) values beyond or
+// at the edge of the representable range.
+#[test]
+fn test_boundaries_miri() {
+    assert!(VouchedTime::check_vouched_time(
+        time::PrimitiveDateTime::MAX
+            .assume_utc()
+            .unix_timestamp_nanos()
+            / 1_000_000,
+        u64::MAX
+    )
+    .is_err());
+    assert!(VouchedTime::check_vouched_time(
+        time::PrimitiveDateTime::MAX
+            .assume_utc()
+            .unix_timestamp_nanos()
+            / 1_000_000,
+        u64::MIN
+    )
+    .is_err());
+    assert!(VouchedTime::check_vouched_time(
+        time::PrimitiveDateTime::MIN
+            .assume_utc()
+            .unix_timestamp_nanos()
+            / 1_000_000,
+        u64::MIN
+    )
+    .is_err());
+    assert!(VouchedTime::check_vouched_time(
+        time::PrimitiveDateTime::MIN
+            .assume_utc()
+            .unix_timestamp_nanos()
+            / 1_000_000,
+        u64::MAX
+    )
+    .is_err());
+
+    VouchedTime::check_vouched_time(0, 0).expect("should pass");
+    VouchedTime::check_vouched_time(0, MAX_BACKWARD_DISCREPANCY_MS).expect("should pass");
+    assert!(VouchedTime::check_vouched_time(0, MAX_BACKWARD_DISCREPANCY_MS + 1).is_err());
+    VouchedTime::check_vouched_time(MAX_FORWARD_DISCREPANCY_MS as i128, 0).expect("should pass");
+    assert!(VouchedTime::check_vouched_time(1 + MAX_FORWARD_DISCREPANCY_MS as i128, 0).is_err());
+
+    // Negative timestamp -> reject.
+    assert!(VouchedTime::check_vouched_time(-1, 0).is_err());
+    assert!(VouchedTime::check_vouched_time(-1, u64::MAX).is_err());
+
+    // Huge timestamps
+    VouchedTime::check_vouched_time(u64::MAX as i128, u64::MAX).expect("should pass");
+    assert!(VouchedTime::check_vouched_time(u64::MAX as i128 + 1, u64::MAX).is_err());
+    VouchedTime::check_vouched_time((u64::MAX - MAX_BACKWARD_DISCREPANCY_MS) as i128, u64::MAX)
+        .expect("should pass");
+    assert!(VouchedTime::check_vouched_time(
+        (u64::MAX - MAX_BACKWARD_DISCREPANCY_MS) as i128 - 1,
+        u64::MAX
+    )
+    .is_err());
+
+    VouchedTime::check_vouched_time(u64::MAX as i128, u64::MAX - MAX_FORWARD_DISCREPANCY_MS)
+        .expect("should pass");
+    assert!(VouchedTime::check_vouched_time(
+        u64::MAX as i128,
+        u64::MAX - MAX_FORWARD_DISCREPANCY_MS - 1
+    )
+    .is_err());
+}

--- a/vouched_time/src/nfs_voucher.rs
+++ b/vouched_time/src/nfs_voucher.rs
@@ -1,0 +1,328 @@
+//! The NFS vouched time backend uses a trusted filesystem's *ctime* to update
+//! the time base.
+//!
+//! Most of the time, the time base can be updated off already opened files.
+//! When the current time base seems far behind, this module can also trigger
+//! an artificial mtime update.
+//!
+//! To use this module as a source of trusted base times for
+//! [`crate::VouchedTime`], you must first add the path to the trusted paths
+//! list.  This is done by calling [`add_trusted_path`] with the path for a
+//! file on a filesystem with trusted ctime updates (e.g., a NFS server
+//! similarly trusted by all peers). The `nfs_voucher` module will now trust
+//! `ctime` for all files on the same device as that path.
+//!
+//! The current process must also have write access to the file at the trusted
+//! path; that's used only to `touch` the file's atime, which forces a ctime
+//! update).
+//!
+//! You can then pass [`get_base_time`] to [`crate::VouchedTime::now_or_die`]
+//! to generate a fresh vouched time for the current time.  The
+//! [`get_base_time`] function will perform I/O and block on some internal
+//! locks to update the base time if it looks like the current base time would
+//! result in a failure. Use [`get_base_time_unlocked`] to skip the I/O and
+//! blocking, and always return the current base time, however stale it might
+//! look.  This should only be used in niche situations where we've already
+//! ensured the base time is up to date and blocking is forbidden.
+//!
+//! You may update the base time (and thue ensure [`get_base_time`] doesn't
+//! block) by calling [`observe_file_time`] with a recently changed file on a
+//! trusted device.  In general, it's always safe to call
+//! [`observe_file_time`] with any file: the function disregards files on
+//! untrusted devices, and base time updates are only applied when they
+//! advance the base time.
+use std::collections::BTreeMap;
+use std::io::Result;
+use std::path::PathBuf;
+use std::sync::RwLock;
+
+use crate::AtomicBaseTime;
+
+// Trusted paths map from device id to path that is safe to touch.
+static TRUSTED_PATHS: RwLock<BTreeMap<u64, PathBuf>> = RwLock::new(BTreeMap::new());
+
+static BASE_TIME: AtomicBaseTime = AtomicBaseTime::new();
+
+/// Adds `path` to the set of trusted paths for the NFS vouching module.
+///
+/// Any file stored on the same device as `path` is assumed to have a
+/// trustworthy ctime.
+///
+/// The current process must have write access to that path, to force ctime updates.
+#[inline(never)]
+pub fn add_trusted_path(path: PathBuf) -> Result<()> {
+    use std::os::unix::fs::MetadataExt;
+
+    let file = std::fs::File::options()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&path)?;
+    let stat = file.metadata()?;
+    let dev = stat.dev();
+    // Check that we can actually use this path for base time updates.
+    //
+    // This call may fail for I/O, but should not fail
+    // because the device isn't trusted (i.e., no `Ok(None)`).
+    let _ = update_base_time(
+        &file,
+        UpdateOptions {
+            blocking: false,
+            touch: true,
+            extra_device: Some(dev),
+        },
+    )?
+    .1
+    .expect("Path is trusted.");
+
+    TRUSTED_PATHS.write().unwrap().insert(dev, path);
+    Ok(())
+}
+
+const DEFAULT_LEEWAY_MS: u64 = 2 * crate::MAX_FORWARD_DISCREPANCY_MS / 3;
+thread_local! {
+    /// The last time we updated the base time, or decided we didn't need to.
+    static LAST_UPDATE: std::cell::Cell<Option<std::time::Instant>> = Default::default();
+}
+
+/// Returns whether it's worth refreshing the current base time, because it's
+/// (approximately) older than `leeway_ms`.
+///
+/// If `leeway_ms` is None, use an appropriate default.
+#[cfg_attr(test, mutants::skip)] // This is pure policy, hard to test with mutants
+pub fn should_refresh_base_time(leeway_ms: Option<u64>, now: Option<time::OffsetDateTime>) -> bool {
+    if now.is_none() {
+        if let Some(last_update) = LAST_UPDATE.get() {
+            // We don't need that kind of precision, just bail early.
+            if last_update.elapsed() < std::time::Duration::from_millis(100) {
+                // TODO: should jitter
+                return false;
+            }
+        }
+    }
+
+    // Either we'll update the base time, or we'll decide it's good enough; in
+    // either case, we shouldn't need to update again for a while.
+    LAST_UPDATE.set(Some(std::time::Instant::now()));
+
+    let leeway_ms = leeway_ms.unwrap_or(DEFAULT_LEEWAY_MS);
+    let now = now.unwrap_or_else(time::OffsetDateTime::now_utc);
+    let wanted: u64 = (now.unix_timestamp_nanos() / 1_000_000).clamp(0, u64::MAX as i128) as u64;
+    let (base_ms, _voucher) = get_base_time_unlocked(now).expect("_unlocked does not fail");
+
+    // Refresh if the base time looks stale and we have some trusted paths to
+    // refresh with.
+    //
+    // TODO: should jitter a little around here.
+    wanted.saturating_sub(base_ms) > leeway_ms && !TRUSTED_PATHS.read().unwrap().is_empty()
+}
+
+/// Given an arbitrary file, attempts to advance the base time based on the
+/// file's ctime.
+///
+/// Returns the base time and voucher derived from the file if it is on a
+/// trusted device (see [`add_trusted_path`]) and the `stat` call succeeded.
+/// That base time may differ from the one stored in memory under contention
+/// or if the file's ctime is older than the current base time.
+///
+/// Returns `Ok(None)` if the file is not on a trusted device, and propagates
+/// any I/O error from `stat` otherwise.
+///
+/// This function `stat`s the file, but is otherwise wait-free.
+#[inline(always)]
+pub fn observe_file_time(
+    file: &std::fs::File,
+) -> Result<(std::fs::Metadata, Option<(u64, raffle::Voucher)>)> {
+    update_base_time(
+        file,
+        UpdateOptions {
+            blocking: false,
+            touch: false,
+            extra_device: None,
+        },
+    )
+}
+
+/// Attempts to advance the base time based on `file`'s ctime, if it makes
+/// sense to refresh the base time (no-ops otherwise).
+pub fn maybe_observe_file_time(file: &std::fs::File) {
+    if should_refresh_base_time(None, None) {
+        let _ = observe_file_time(file);
+    }
+}
+
+/// Attempts to update the base time if it is already stale (more than 1000
+/// milliseconds behind).
+#[inline(never)]
+pub fn scan_base_time() -> Result<()> {
+    // We want to be more aggressive than the default leeway, when explicitly
+    // requesting a base time update.
+    const _: () = assert!(1000 < DEFAULT_LEEWAY_MS);
+    if should_refresh_base_time(Some(1000), None) {
+        scan_for_base_time_impl()?;
+    }
+
+    Ok(())
+}
+
+/// Returns the current base time and voucher.
+///
+/// Does not attempt to move the base time forward if it looks stale,
+/// but also never fails.
+///
+/// This function is lock-free.
+#[inline(always)]
+pub fn get_base_time_unlocked(_now: time::OffsetDateTime) -> Result<(u64, raffle::Voucher)> {
+    Ok(BASE_TIME.snapshot())
+}
+
+/// Attempts to return an up-to-date base time and voucher.
+///
+/// Returns the current base time if it looks more than recent enough to match
+/// the current time. Otherwise, attempts to update the base time by touching
+/// some of the trusted paths and returns the first successful update.
+///
+/// This function fails when all update attempts fail, and when no trusted
+/// path is defined.
+///
+/// This function is lock-free when the base time is up to date; if the base
+/// time must be updated, that can be slow, and requires I/O and locking.
+pub fn get_base_time(now: time::OffsetDateTime) -> Result<(u64, raffle::Voucher)> {
+    if should_refresh_base_time(None, Some(now)) {
+        scan_for_base_time_impl()
+    } else {
+        get_base_time_unlocked(now)
+    }
+}
+
+#[inline(never)]
+fn scan_for_base_time_impl() -> Result<(u64, raffle::Voucher)> {
+    let mut err: Option<std::io::Error> = None;
+    let trusted_paths = TRUSTED_PATHS.read().unwrap();
+    for path in trusted_paths.values() {
+        let file = std::fs::File::options()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)?;
+        match update_base_time(
+            &file,
+            UpdateOptions {
+                blocking: true,
+                touch: true,
+                extra_device: None,
+            },
+        ) {
+            Ok((_, Some(update))) => return Ok(update),
+            Ok(_) => {}
+            Err(e) => {
+                err.get_or_insert(e);
+            }
+        }
+    }
+
+    Err(err.unwrap_or_else(|| {
+        std::io::Error::other(
+            "no nfs_voucher trusted path (or all paths moved to a different device)",
+        )
+    }))
+}
+
+struct UpdateOptions {
+    blocking: bool,
+    touch: bool,
+    extra_device: Option<u64>,
+}
+
+#[inline(never)]
+fn update_base_time(
+    file: &std::fs::File,
+    options: UpdateOptions,
+) -> Result<(std::fs::Metadata, Option<(u64, raffle::Voucher)>)> {
+    use std::os::unix::fs::MetadataExt;
+
+    if options.touch {
+        file.set_times(std::fs::FileTimes::new().set_accessed(std::time::SystemTime::now()))?;
+    }
+
+    let begin = std::time::Instant::now();
+
+    let stat = file.metadata()?;
+    let dev = stat.dev();
+    if !TRUSTED_PATHS.read().unwrap().contains_key(&dev) && options.extra_device != Some(dev) {
+        return Ok((stat, None));
+    }
+    const VOUCH_PARAMS: raffle::VouchingParameters = raffle::VouchingParameters::parse_or_die(
+        "VOUCH-773ec2a0e62c20cd-f9e079b78e895091-fc1da7b1b77c57cb-594b9cce3091464a",
+    );
+
+    let millis_since_epoch = (stat.ctime() as u64)
+        .saturating_mul(1000)
+        .saturating_add((stat.ctime_nsec() as u64) / 1_000_000);
+    let update = (millis_since_epoch, VOUCH_PARAMS.vouch(millis_since_epoch));
+
+    let updated = if options.blocking {
+        BASE_TIME.update(update);
+        true
+    } else {
+        BASE_TIME.try_update(update)
+    };
+
+    if updated {
+        LAST_UPDATE.set(Some(begin));
+    }
+
+    Ok((stat, Some(update)))
+}
+
+// This smoke test depends on global state, real time, and the
+// external filesystem.  To split it up in smaller tests, first
+// make it run in forked subprocesses.
+#[cfg(not(miri))]
+#[test]
+fn smoke_test() {
+    use test_dir::{DirBuilder, TestDir};
+
+    let temp = TestDir::temp();
+    add_trusted_path(temp.path("test.file")).expect("should succeed");
+    let _ = crate::VouchedTime::now_or_die(get_base_time_unlocked);
+
+    // The base time is now invalid.
+    std::thread::sleep(std::time::Duration::from_secs(4));
+
+    // Confirm it's invalid.
+    assert!(crate::VouchedTime::now(get_base_time_unlocked).is_err());
+    // But we can pull the base time forward.
+    let _ = crate::VouchedTime::now_or_die(get_base_time);
+    let _ = crate::VouchedTime::now_or_die(get_base_time);
+    let _ = crate::VouchedTime::now_or_die(get_base_time_unlocked);
+
+    // Invalidate the base time again.
+    std::thread::sleep(std::time::Duration::from_secs(4));
+    assert!(crate::VouchedTime::now(get_base_time_unlocked).is_err());
+
+    std::fs::write(temp.path("some_random_file"), b"123").unwrap();
+    let file = std::fs::File::open(temp.path("some_random_file")).unwrap();
+    // Update base time
+    maybe_observe_file_time(&file);
+    // Back to back calls should return false.
+    assert!(!should_refresh_base_time(None, None));
+    maybe_observe_file_time(&file); // Back-to-back calls should succeed.
+    let _ = crate::VouchedTime::now_or_die(get_base_time_unlocked);
+
+    std::thread::sleep(std::time::Duration::from_secs(4));
+    assert!(crate::VouchedTime::now(get_base_time_unlocked).is_err());
+    scan_base_time().expect("should work");
+    scan_base_time().expect("should work"); // Back-to-back calls should work.
+    let _ = crate::VouchedTime::now_or_die(get_base_time_unlocked);
+}
+
+#[cfg(not(miri))]
+#[test]
+fn test_back_to_back_should_refresh() {
+    should_refresh_base_time(None, None);
+    // Back to back calls should return false.
+    assert!(!should_refresh_base_time(None, None));
+}


### PR DESCRIPTION
In distributed systems like the woodpile, it's important for some timestamps to be in the same vicinity as the "real" real time.

Unlike Spanner, the error bar on the timestamps doesn't have to be tight to the microsecond.  However, we assume that all peers can agreee on the current time up to ~2 seconds (the error budget is split evenly between leap second handling and clock sync error).

The vouched time crate uses a slowly updated "trusted" time and vouches that a fresh timestamp isn't too far from the most recent trusted time.  Roughtime servers were designed as trusted time sources, but the ecosystem doesn't look great (very few implementations, the latest version of the RFC is very different from the most common implementation, prototype-quality Rust client)... so we just use ctime from trusted mount points (e.g., NFS servers): on NFS, the ctime is always set by the server, so, while that time source might be badly synchronised with reality, everyone should be able to agree on the same time.

Start reading at atomic_base_time, then `lib.rs`.  The `nfs_voucher` module is mostly uninteresting filesystem manipulation, and "just" implements the logic needed by the `VouchedTime` class on top of `atomic_base_time`.